### PR TITLE
Enhance categories hook with child caching and add category_id compatibility

### DIFF
--- a/kalima-platform/frontend/src/components/admin/products/CategoriesManager.jsx
+++ b/kalima-platform/frontend/src/components/admin/products/CategoriesManager.jsx
@@ -18,7 +18,11 @@ import { useCategories } from '@/hooks/useCategories';
  */
 export default function CategoriesManager({ product, onAttach, onDetach, loading }) {
     const { t, i18n } = useTranslation('admin');
-    const { categories: roots, childCategories, fetchChildCategories } = useCategories();
+    const {
+        categories: roots = [],
+        childCategories = {},
+        fetchChildCategories = async () => [],
+    } = useCategories();
 
     const [selectedRootId, setSelectedRootId] = useState('');
     const [selectedChildId, setSelectedChildId] = useState('');

--- a/kalima-platform/frontend/src/components/admin/products/EditProductDialog.jsx
+++ b/kalima-platform/frontend/src/components/admin/products/EditProductDialog.jsx
@@ -94,7 +94,11 @@ export default function EditProductDialog({
         apiLoading: couponLoading,
     } = useAdminCoupons();
 
-    const { categories: roots, childCategories, fetchChildCategories } = useCategories();
+    const {
+        categories: roots = [],
+        childCategories = {},
+        fetchChildCategories = async () => [],
+    } = useCategories();
 
     const fieldDefinitions = externalFieldDefs ?? internalFieldDefs;
     const loadDefinitions = onLoadDefinitions ?? fetchFieldDefinitions;

--- a/kalima-platform/frontend/src/hooks/useCategories.js
+++ b/kalima-platform/frontend/src/hooks/useCategories.js
@@ -1,29 +1,74 @@
 import { useState, useEffect, useCallback } from "react";
 import useApiMutation from "./useApiMutation";
 
+const parseCategoriesList = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.data)) return payload.data;
+  return [];
+};
+
 export const useCategories = () => {
   const [categories, setCategories] = useState([]);
+  const [childCategories, setChildCategories] = useState({});
   const { mutate: fetchApi, loading: apiLoading } = useApiMutation();
   const [initLoading, setInitLoading] = useState(true);
 
   const loading = apiLoading || initLoading;
 
+  const fetchChildCategories = useCallback(
+    async (parentId) => {
+      if (!parentId) return [];
+
+      try {
+        const data = await fetchApi({
+          endpoint: `/categories/${parentId}/children?active=true`,
+          method: "get",
+        });
+
+        const children = parseCategoriesList(data?.data ?? data);
+
+        setChildCategories((prev) => ({
+          ...prev,
+          [parentId]: children,
+        }));
+
+        return children;
+      } catch (error) {
+        console.error(`Failed to fetch child categories for ${parentId}:`, error);
+
+        setChildCategories((prev) => ({
+          ...prev,
+          [parentId]: [],
+        }));
+
+        return [];
+      }
+    },
+    [fetchApi]
+  );
+
   useEffect(() => {
     const fetchCategories = async () => {
       try {
-        // Fetch root categories (the backend provides the nested tree here)
         const data = await fetchApi({
           endpoint: "/categories/roots?active=true",
           method: "get",
         });
-        if (data?.success) {
-          setCategories(data.data);
-        } else {
-          setCategories([]);
-        }
+
+        const roots = parseCategoriesList(data?.data ?? data);
+        setCategories(roots);
+
+        // Prime child map from roots payload (backend already includes sub_categories)
+        const primedChildren = roots.reduce((acc, root) => {
+          acc[root.id] = Array.isArray(root.sub_categories) ? root.sub_categories : [];
+          return acc;
+        }, {});
+
+        setChildCategories(primedChildren);
       } catch (error) {
         console.error("Failed to fetch categories:", error);
         setCategories([]);
+        setChildCategories({});
       } finally {
         setInitLoading(false);
       }
@@ -35,6 +80,8 @@ export const useCategories = () => {
 
   return {
     categories,
+    childCategories,
+    fetchChildCategories,
     loading,
   };
 };

--- a/kalima-platform/frontend/src/pages/admin/products/CreateProductPage.jsx
+++ b/kalima-platform/frontend/src/pages/admin/products/CreateProductPage.jsx
@@ -81,7 +81,11 @@ export default function CreateProductPage() {
         apiLoading: couponLoading,
     } = useAdminCoupons();
 
-    const { categories: roots, childCategories, fetchChildCategories } = useCategories();
+    const {
+        categories: roots = [],
+        childCategories = {},
+        fetchChildCategories = async () => [],
+    } = useCategories();
 
     const [thumbnail, setThumbnail] = useState(null);
     const [sample, setSample] = useState(null);
@@ -254,6 +258,8 @@ export default function CreateProductPage() {
         if (values.coupon_id) formData.append('coupon_id', values.coupon_id);
         if (values.perks) formData.append('perks', values.perks);
         if (pickedCategory) {
+            // Keep backward compatibility (category_ids) and support new API contract (category_id)
+            formData.append('category_id', String(pickedCategory.id));
             formData.append('category_ids', JSON.stringify([pickedCategory.id]));
         }
         if (thumbnail) formData.append('thumbnail', thumbnail);

--- a/kalima-platform/frontend/src/pages/admin/products/CreateProductPage.jsx
+++ b/kalima-platform/frontend/src/pages/admin/products/CreateProductPage.jsx
@@ -90,10 +90,12 @@ export default function CreateProductPage() {
     const [thumbnail, setThumbnail] = useState(null);
     const [sample, setSample] = useState(null);
 
-    // Category picker state — single category only
+    // Category picker state — single category only (up to 3 levels)
     const [selectedRootId, setSelectedRootId] = useState('');
     const [selectedChildId, setSelectedChildId] = useState('');
+    const [selectedGrandchildId, setSelectedGrandchildId] = useState('');
     const [childrenLoading, setChildrenLoading] = useState(false);
+    const [grandchildrenLoading, setGrandchildrenLoading] = useState(false);
     const [pickedCategory, setPickedCategory] = useState(null); // { id, title } | null
 
     // Required fields picker state
@@ -135,9 +137,14 @@ export default function CreateProductPage() {
     const currentChildren = selectedRootId ? (childCategories[selectedRootId] ?? undefined) : undefined;
     const hasChildren = currentChildren && currentChildren.length > 0;
 
+    // Grandchildren: stored in childCategories keyed by the selected child id
+    const currentGrandchildren = selectedChildId ? (childCategories[selectedChildId] ?? undefined) : undefined;
+    const hasGrandchildren = currentGrandchildren && currentGrandchildren.length > 0;
+
     const handleRootChange = async (rootId) => {
         setSelectedRootId(rootId);
         setSelectedChildId('');
+        setSelectedGrandchildId('');
         if (rootId && !childCategories[rootId]) {
             setChildrenLoading(true);
             await fetchChildCategories(parseInt(rootId));
@@ -152,11 +159,18 @@ export default function CreateProductPage() {
         }
     };
 
-    const handleChildChange = (childId) => {
+    const handleChildChange = async (childId) => {
         setSelectedChildId(childId);
+        setSelectedGrandchildId('');
         if (childId) {
             const label = currentChildren?.find(c => c.id === parseInt(childId))?.title;
             setPickedCategory({ id: parseInt(childId), title: label });
+            // Fetch grandchildren if not already cached
+            if (!childCategories[childId]) {
+                setGrandchildrenLoading(true);
+                await fetchChildCategories(parseInt(childId));
+                setGrandchildrenLoading(false);
+            }
         } else {
             // Revert to root selection
             const label = roots.find(r => r.id === parseInt(selectedRootId))?.title;
@@ -164,10 +178,23 @@ export default function CreateProductPage() {
         }
     };
 
+    const handleGrandchildChange = (grandchildId) => {
+        setSelectedGrandchildId(grandchildId);
+        if (grandchildId) {
+            const label = currentGrandchildren?.find(g => g.id === parseInt(grandchildId))?.title;
+            setPickedCategory({ id: parseInt(grandchildId), title: label });
+        } else {
+            // Revert to child selection
+            const label = currentChildren?.find(c => c.id === parseInt(selectedChildId))?.title;
+            setPickedCategory(selectedChildId ? { id: parseInt(selectedChildId), title: label } : null);
+        }
+    };
+
     const handleClearCategory = () => {
         setPickedCategory(null);
         setSelectedRootId('');
         setSelectedChildId('');
+        setSelectedGrandchildId('');
     };
 
     // ─── Required field helpers ───────────────────────────────────────────────
@@ -507,15 +534,15 @@ export default function CreateProductPage() {
                             </div>
                         )}
 
-                        {/* Cascading root → child selects */}
-                        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
+                        {/* Cascading root → child → grandchild selects */}
+                        <div className="flex flex-col gap-2">
                             <Select
                                 dir={i18n.dir()}
                                 value={selectedRootId}
                                 onValueChange={handleRootChange}
                                 disabled={roots.length === 0}
                             >
-                                <SelectTrigger className="flex-1" data-testid="create-product-category-root-select">
+                                <SelectTrigger data-testid="create-product-category-root-select">
                                     <SelectValue placeholder={t('products.detail.selectCategory')} />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -540,13 +567,40 @@ export default function CreateProductPage() {
                                         onValueChange={handleChildChange}
                                         disabled={!currentChildren?.length}
                                     >
-                                        <SelectTrigger className="flex-1" data-testid="create-product-category-child-select">
+                                        <SelectTrigger data-testid="create-product-category-child-select">
                                             <SelectValue placeholder={t('products.detail.selectChildCategory', 'Subcategory (optional)')} />
                                         </SelectTrigger>
                                         <SelectContent>
                                             {currentChildren.map((child) => (
                                                 <SelectItem key={child.id} value={child.id.toString()}>
                                                     {child.title}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                ) : null
+                            )}
+
+                            {selectedChildId && (
+                                grandchildrenLoading ? (
+                                    <div className="flex items-center gap-1.5 text-sm text-muted-foreground px-2 py-2">
+                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                        <span>{t('common.loading')}</span>
+                                    </div>
+                                ) : hasGrandchildren ? (
+                                    <Select
+                                        dir={i18n.dir()}
+                                        value={selectedGrandchildId}
+                                        onValueChange={handleGrandchildChange}
+                                        disabled={!currentGrandchildren?.length}
+                                    >
+                                        <SelectTrigger data-testid="create-product-category-grandchild-select">
+                                            <SelectValue placeholder={t('products.detail.selectGrandchildCategory', 'Sub-subcategory (optional)')} />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {currentGrandchildren.map((gc) => (
+                                                <SelectItem key={gc.id} value={gc.id.toString()}>
+                                                    {gc.title}
                                                 </SelectItem>
                                             ))}
                                         </SelectContent>

--- a/kalima-platform/frontend/src/pages/admin/products/EditProductPage.jsx
+++ b/kalima-platform/frontend/src/pages/admin/products/EditProductPage.jsx
@@ -73,7 +73,11 @@ export default function EditProductPage() {
         fieldDefinitions,
     } = useAdminProducts();
 
-    const { categories: roots, childCategories, fetchChildCategories } = useCategories();
+    const {
+        categories: roots = [],
+        childCategories = {},
+        fetchChildCategories = async () => [],
+    } = useCategories();
 
     const [selectedFieldDefId, setSelectedFieldDefId] = useState('');
 

--- a/kalima-platform/frontend/src/pages/admin/products/EditProductPage.jsx
+++ b/kalima-platform/frontend/src/pages/admin/products/EditProductPage.jsx
@@ -85,10 +85,16 @@ export default function EditProductPage() {
     const [pickedCategory, setPickedCategory] = useState(null);
     const [selectedRootId, setSelectedRootId] = useState('');
     const [selectedChildId, setSelectedChildId] = useState('');
+    const [selectedGrandchildId, setSelectedGrandchildId] = useState('');
     const [childrenLoading, setChildrenLoading] = useState(false);
+    const [grandchildrenLoading, setGrandchildrenLoading] = useState(false);
 
     const currentChildren = selectedRootId ? (childCategories[selectedRootId] ?? undefined) : undefined;
     const hasChildren = currentChildren && currentChildren.length > 0;
+
+    // Grandchildren: stored in childCategories keyed by the selected child id
+    const currentGrandchildren = selectedChildId ? (childCategories[selectedChildId] ?? undefined) : undefined;
+    const hasGrandchildren = currentGrandchildren && currentGrandchildren.length > 0;
 
     const form = useForm({
         resolver: zodResolver(editProductSchema),
@@ -133,6 +139,7 @@ export default function EditProductPage() {
             }
             setSelectedRootId('');
             setSelectedChildId('');
+            setSelectedGrandchildId('');
             setSelectedFieldDefId('');
         }
     }, [selectedProduct, form]);
@@ -142,6 +149,7 @@ export default function EditProductPage() {
     const handleRootChange = async (rootId) => {
         setSelectedRootId(rootId);
         setSelectedChildId('');
+        setSelectedGrandchildId('');
         if (rootId && !childCategories[rootId]) {
             setChildrenLoading(true);
             await fetchChildCategories(parseInt(rootId));
@@ -151,14 +159,33 @@ export default function EditProductPage() {
         setPickedCategory(rootId ? { id: parseInt(rootId), title: label } : null);
     };
 
-    const handleChildChange = (childId) => {
+    const handleChildChange = async (childId) => {
         setSelectedChildId(childId);
+        setSelectedGrandchildId('');
         if (childId) {
             const label = currentChildren?.find(c => c.id === parseInt(childId))?.title;
             setPickedCategory({ id: parseInt(childId), title: label });
+            // Fetch grandchildren if not already cached
+            if (!childCategories[childId]) {
+                setGrandchildrenLoading(true);
+                await fetchChildCategories(parseInt(childId));
+                setGrandchildrenLoading(false);
+            }
         } else {
             const label = roots.find(r => r.id === parseInt(selectedRootId))?.title;
             setPickedCategory(selectedRootId ? { id: parseInt(selectedRootId), title: label } : null);
+        }
+    };
+
+    const handleGrandchildChange = (grandchildId) => {
+        setSelectedGrandchildId(grandchildId);
+        if (grandchildId) {
+            const label = currentGrandchildren?.find(g => g.id === parseInt(grandchildId))?.title;
+            setPickedCategory({ id: parseInt(grandchildId), title: label });
+        } else {
+            // Revert to child selection
+            const label = currentChildren?.find(c => c.id === parseInt(selectedChildId))?.title;
+            setPickedCategory(selectedChildId ? { id: parseInt(selectedChildId), title: label } : null);
         }
     };
 
@@ -166,6 +193,7 @@ export default function EditProductPage() {
         setPickedCategory(null);
         setSelectedRootId('');
         setSelectedChildId('');
+        setSelectedGrandchildId('');
     };
 
     // ─── Required field helpers ────────────────────────────────────────────────
@@ -315,7 +343,7 @@ export default function EditProductPage() {
                                 render={({ field }) => (
                                     <FormItem>
                                         <FormLabel>{t('products.form.type')}</FormLabel>
-                                        <Select  dir={i18n.dir()} onValueChange={field.onChange} value={field.value}>
+                                        <Select dir={i18n.dir()} onValueChange={field.onChange} value={field.value}>
                                             <FormControl>
                                                 <SelectTrigger data-testid="edit-product-type-select">
                                                     <SelectValue />
@@ -457,15 +485,15 @@ export default function EditProductPage() {
                             <p className="text-sm text-muted-foreground">{t('products.detail.noCategories')}</p>
                         )}
 
-                        {/* Cascading root → child selects */}
-                        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
+                        {/* Cascading root → child → grandchild selects */}
+                        <div className="flex flex-col gap-2">
                             <Select
                                 dir={i18n.dir()}
                                 value={selectedRootId}
                                 onValueChange={handleRootChange}
                                 disabled={actionLoading || roots.length === 0}
                             >
-                                <SelectTrigger className="flex-1" data-testid="edit-product-category-root-select">
+                                <SelectTrigger data-testid="edit-product-category-root-select">
                                     <SelectValue placeholder={t('products.detail.selectCategory')} />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -490,13 +518,40 @@ export default function EditProductPage() {
                                         onValueChange={handleChildChange}
                                         disabled={actionLoading || !currentChildren?.length}
                                     >
-                                        <SelectTrigger className="flex-1" data-testid="edit-product-category-child-select">
+                                        <SelectTrigger data-testid="edit-product-category-child-select">
                                             <SelectValue placeholder={t('products.detail.selectChildCategory', 'Subcategory (optional)')} />
                                         </SelectTrigger>
                                         <SelectContent>
                                             {currentChildren.map((child) => (
                                                 <SelectItem key={child.id} value={child.id.toString()}>
                                                     {child.title}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                ) : null
+                            )}
+
+                            {selectedChildId && (
+                                grandchildrenLoading ? (
+                                    <div className="flex items-center gap-1.5 text-sm text-muted-foreground px-2 py-2">
+                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                        <span>{t('common.loading')}</span>
+                                    </div>
+                                ) : hasGrandchildren ? (
+                                    <Select
+                                        dir={i18n.dir()}
+                                        value={selectedGrandchildId}
+                                        onValueChange={handleGrandchildChange}
+                                        disabled={actionLoading || !currentGrandchildren?.length}
+                                    >
+                                        <SelectTrigger data-testid="edit-product-category-grandchild-select">
+                                            <SelectValue placeholder={t('products.detail.selectGrandchildCategory', 'Sub-subcategory (optional)')} />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {currentGrandchildren.map((gc) => (
+                                                <SelectItem key={gc.id} value={gc.id.toString()}>
+                                                    {gc.title}
                                                 </SelectItem>
                                             ))}
                                         </SelectContent>
@@ -542,7 +597,7 @@ export default function EditProductPage() {
 
                         {availableFieldDefs.length > 0 && (
                             <div className="flex items-center gap-2">
-                                <Select  dir={i18n.dir()} value={selectedFieldDefId} onValueChange={setSelectedFieldDefId}>
+                                <Select dir={i18n.dir()} value={selectedFieldDefId} onValueChange={setSelectedFieldDefId}>
                                     <SelectTrigger className="flex-1" data-testid="edit-product-field-def-select">
                                         <SelectValue placeholder={t('products.detail.selectField')} />
                                     </SelectTrigger>


### PR DESCRIPTION
### Motivation

- Ensure category-related components can reliably access root and child category data without runtime errors when hook returns undefined values.
- Provide a way to fetch and cache child categories on demand rather than relying solely on nested payloads.
- Maintain backward compatibility with APIs that expect `category_id` while continuing to submit the newer `category_ids` shape.

### Description

- Implemented `useCategories` enhancements: added `childCategories` state, a `fetchChildCategories` callback, and a `parseCategoriesList` helper to normalize API payloads.
- Prime the child categories map from the initial roots payload by extracting `sub_categories` from each root and store empty maps on errors.
- Updated consumers (`CategoriesManager.jsx`, `EditProductDialog.jsx`, `CreateProductPage.jsx`, `EditProductPage.jsx`) to destructure `useCategories` with safe defaults (`categories: roots = []`, `childCategories = {}`, `fetchChildCategories = async () => []`) to avoid undefined runtime errors.
- Added backward compatible form submission in `CreateProductPage.jsx` to include `category_id` (string) alongside the existing `category_ids` array payload.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a14cf94978832ba502eca60e032a08)