### PR TITLE
fix: render e-booklet PDFs in viewer

### DIFF
--- a/kalima-platform/backend/src/apps/store-api/controllers/e-booklet.controller.ts
+++ b/kalima-platform/backend/src/apps/store-api/controllers/e-booklet.controller.ts
@@ -1118,6 +1118,41 @@ export const eBookletController = {
     }
   },
 
+  async getAuthorizedViewerDocument(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { asset, absolutePath } = await getEBookletService().getAuthorizedViewerDocument(
+        parseId(req.params.instanceId, "instance ID"),
+        currentUserId(req),
+      );
+      setPrivateNoStore(res);
+      res.type(asset.mime_type || "application/pdf");
+      res.set(
+        "Content-Disposition",
+        `inline; filename="${String(asset.original_filename || "e-booklet-document.pdf").replace(/"/g, "")}"`,
+      );
+      res.sendFile(absolutePath);
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async getAdminAuthorizedViewerDocument(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { asset, absolutePath } = await getEBookletService().getAdminAuthorizedViewerDocument(
+        parseId(req.params.instanceId, "instance ID"),
+      );
+      setPrivateNoStore(res);
+      res.type(asset.mime_type || "application/pdf");
+      res.set(
+        "Content-Disposition",
+        `inline; filename="${String(asset.original_filename || "e-booklet-document.pdf").replace(/"/g, "")}"`,
+      );
+      res.sendFile(absolutePath);
+    } catch (error) {
+      next(error);
+    }
+  },
+
   async getAuthorizedHotspotAsset(req: Request, res: Response, next: NextFunction) {
     try {
       const { asset, absolutePath } = await getEBookletService().getAuthorizedHotspotAsset(

--- a/kalima-platform/backend/src/apps/store-api/routes/v2/e-booklet.routes.ts
+++ b/kalima-platform/backend/src/apps/store-api/routes/v2/e-booklet.routes.ts
@@ -394,6 +394,12 @@ router.get(
   eBookletController.getAdminViewerMetadata,
 );
 router.get(
+  "/admin/e-booklet-viewer/:instanceId/document",
+  viewerLimiter,
+  ...adminAuth,
+  eBookletController.getAdminAuthorizedViewerDocument,
+);
+router.get(
   "/admin/e-booklet-viewer/:instanceId/pages/:pageNumber",
   viewerLimiter,
   ...adminAuth,
@@ -430,6 +436,12 @@ router.post(
   viewerLimiter,
   ...viewerAuth,
   eBookletController.bindViewerDevice,
+);
+router.get(
+  "/e-booklet-viewer/:instanceId/document",
+  viewerLimiter,
+  ...viewerAuth,
+  eBookletController.getAuthorizedViewerDocument,
 );
 router.get(
   "/e-booklet-viewer/:instanceId/pages/:pageNumber",

--- a/kalima-platform/backend/src/apps/store-api/services/e-booklet.service.ts
+++ b/kalima-platform/backend/src/apps/store-api/services/e-booklet.service.ts
@@ -1912,12 +1912,22 @@ export class EBookletService {
     return access;
   }
 
+  private resolveViewerDocumentAssetId(instance: any): number | null {
+    const assetId =
+      instance?.custom_document_file_id ??
+      instance?.template_version?.rendered_document_file_id ??
+      instance?.template_version?.base_document_file_id ??
+      null;
+    return assetId ? Number(assetId) : null;
+  }
+
   async getAdminViewerPage(instanceId: number, pageNumber: number, adminUserId: number) {
     const access: any = await this.getAdminViewerAccess(instanceId);
     const pageCount = Number(access.booklet_instance?.template_version?.page_count || 0);
     if (!Number.isInteger(pageNumber) || pageNumber < 1 || pageNumber > pageCount) {
       throw new BadRequestError("Invalid e-booklet page number.");
     }
+    const documentAssetId = this.resolveViewerDocumentAssetId(access.booklet_instance);
     const expiresAt = new Date(Date.now() + VIEWER_PAGE_TOKEN_TTL_MS);
     await this.db.e_booklet_audit_logs.create({
       data: {
@@ -1930,7 +1940,8 @@ export class EBookletService {
     });
     return {
       pageNumber,
-      renderMode: "server-page",
+      renderMode: documentAssetId ? "pdf-document" : "server-page",
+      documentAssetId,
       pageAccessToken: createViewerPageToken({ instanceId, pageNumber, userId: adminUserId, expiresAt }),
       expiresAt,
       cacheControl: "private, no-store",
@@ -2022,6 +2033,40 @@ export class EBookletService {
     };
   }
 
+  private async buildViewerDocumentResponse(instance: any) {
+    const documentAssetId = this.resolveViewerDocumentAssetId(instance);
+    if (!documentAssetId) {
+      throw new NotFoundError("E-booklet document is not available.");
+    }
+    const asset = await this.db.e_booklet_file_assets.findUnique({ where: { id: documentAssetId } });
+    if (!asset || asset.mime_type !== "application/pdf") {
+      throw new NotFoundError("E-booklet PDF document not found.");
+    }
+    const filename = path.basename(asset.storage_key || "");
+    return {
+      asset: {
+        id: asset.id,
+        file_type: asset.file_type,
+        original_filename: asset.original_filename,
+        mime_type: asset.mime_type,
+        size_bytes: asset.size_bytes,
+        visibility: asset.visibility,
+      },
+      absolutePath: path.join(E_BOOKLET_UPLOAD_DIR, filename),
+      cacheControl: "private, no-store",
+    };
+  }
+
+  async getAdminAuthorizedViewerDocument(instanceId: number) {
+    const access: any = await this.getAdminViewerAccess(instanceId);
+    return this.buildViewerDocumentResponse(access.booklet_instance);
+  }
+
+  async getAuthorizedViewerDocument(instanceId: number, userId: number) {
+    const access: any = await this.assertViewerAccess(instanceId, userId);
+    return this.buildViewerDocumentResponse(access.booklet_instance);
+  }
+
   async getViewerMetadata(instanceId: number, userId: number) {
     const access = await this.assertViewerAccess(instanceId, userId);
     await this.db.e_booklet_audit_logs.create({
@@ -2073,9 +2118,11 @@ export class EBookletService {
       source: access.access_source,
       metadata: { page_number: pageNumber },
     });
+    const documentAssetId = this.resolveViewerDocumentAssetId(access.booklet_instance);
     return {
       pageNumber,
-      renderMode: "server-page",
+      renderMode: documentAssetId ? "pdf-document" : "server-page",
+      documentAssetId,
       pageAccessToken: createViewerPageToken({
         instanceId,
         pageNumber,
@@ -2088,7 +2135,9 @@ export class EBookletService {
         teacherName: access.booklet_instance?.teacher?.name || null,
         templateTitle: access.booklet_instance?.template?.title || null,
       },
-      message: "Page rendering pipeline is pending document renderer integration.",
+      message: documentAssetId
+        ? null
+        : "Page rendering pipeline is pending document renderer integration.",
     };
   }
 

--- a/kalima-platform/backend/tests/e-booklet/e-booklet.routes.spec.ts
+++ b/kalima-platform/backend/tests/e-booklet/e-booklet.routes.spec.ts
@@ -1,6 +1,9 @@
 import express from "express";
 import request from "supertest";
 import jwt from "jsonwebtoken";
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
 
 process.env.DATABASE_URL =
   process.env.DATABASE_URL || "postgresql://postgres:postgres@localhost:5432/postgres?schema=test";
@@ -64,12 +67,14 @@ const mockService = {
   getAdminViewerPageHotspots: jest.fn(),
   getAdminHotspotContent: jest.fn(),
   getAdminAuthorizedHotspotAsset: jest.fn(),
+  getAdminAuthorizedViewerDocument: jest.fn(),
   bindViewerDevice: jest.fn(),
   listViewerDevices: jest.fn(),
   resetViewerDevices: jest.fn(),
   addDeviceAllowance: jest.fn(),
   approveStudentPurchaseLink: jest.fn(),
   getAuthorizedHotspotAsset: jest.fn(),
+  getAuthorizedViewerDocument: jest.fn(),
   createFileAsset: jest.fn(),
   recordInviteOpen: jest.fn(),
   getTeacherAnalytics: jest.fn(),
@@ -445,6 +450,30 @@ describe("e-booklet routes", () => {
       });
 
     expect(mockService.getViewerPage).toHaveBeenCalledWith(10, 1, 55);
+  });
+
+  test("serves the authorized viewer PDF document as private no-store", async () => {
+    const pdfPath = path.join(os.tmpdir(), `kalima-viewer-${Date.now()}.pdf`);
+    await fs.writeFile(pdfPath, Buffer.from("%PDF-1.4\n%stub\n"));
+    mockService.getAuthorizedViewerDocument.mockResolvedValue({
+      asset: { original_filename: "lesson.pdf", mime_type: "application/pdf" },
+      absolutePath: pdfPath,
+      cacheControl: "private, no-store",
+    });
+
+    try {
+      await request(app)
+        .get("/api/v2/e-booklet-viewer/10/document")
+        .set("Authorization", `Bearer ${tokenFor("Student", 55)}`)
+        .expect(200)
+        .expect("Cache-Control", "private, no-store")
+        .expect("Content-Type", /application\/pdf/)
+        .expect("Content-Disposition", /inline; filename="lesson.pdf"/);
+
+      expect(mockService.getAuthorizedViewerDocument).toHaveBeenCalledWith(10, 55);
+    } finally {
+      await fs.rm(pdfPath, { force: true });
+    }
   });
 
   test("serves admin view mode without student access or device binding", async () => {

--- a/kalima-platform/backend/tests/e-booklet/e-booklet.service.spec.ts
+++ b/kalima-platform/backend/tests/e-booklet/e-booklet.service.spec.ts
@@ -1400,9 +1400,12 @@ describe("EBookletService", () => {
           access_source: "offline_passcode",
           teacher: { id: 99, name: "Ms. Sara" },
           template: { id: 7, title: "Grade 5 Arabic" },
+          custom_document_file_id: 99,
           template_version: {
             id: 22,
             page_count: 3,
+            base_document_file_id: 88,
+            rendered_document_file_id: 77,
           },
         },
       });
@@ -1414,7 +1417,9 @@ describe("EBookletService", () => {
       expect(result).toEqual(
         expect.objectContaining({
           pageNumber: 2,
-          renderMode: "server-page",
+          renderMode: "pdf-document",
+          documentAssetId: 99,
+          message: null,
           pageAccessToken: expect.stringMatching(
             /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
           ),

--- a/kalima-platform/frontend/src/hooks/useEBookletAccess.js
+++ b/kalima-platform/frontend/src/hooks/useEBookletAccess.js
@@ -284,6 +284,14 @@ export function useEBookletViewer({ adminMode = false } = {}) {
     [fetchApi],
   );
 
+  const fetchViewerDocumentBlobUrl = useCallback(async (instanceId) => {
+    const response = await api.get(
+      `${viewerBase}/${instanceId}/document`,
+      { responseType: "blob" },
+    );
+    return URL.createObjectURL(response.data);
+  }, [viewerBase]);
+
   const fetchHotspotAssetBlobUrl = useCallback(async (hotspotId, assetId) => {
     const response = await api.get(
       `${viewerBase}/hotspots/${hotspotId}/assets/${assetId}`,
@@ -301,6 +309,7 @@ export function useEBookletViewer({ adminMode = false } = {}) {
     fetchPage,
     fetchHotspotContent,
     bindDevice,
+    fetchViewerDocumentBlobUrl,
     fetchHotspotAssetBlobUrl,
   };
 }

--- a/kalima-platform/frontend/src/pages/e-booklets/EBookletViewerPage.jsx
+++ b/kalima-platform/frontend/src/pages/e-booklets/EBookletViewerPage.jsx
@@ -383,6 +383,7 @@ export default function EBookletViewerPage() {
   const [zoom, setZoom] = useState(1);
   const [activeHotspot, setActiveHotspot] = useState(null);
   const [hotspotContent, setHotspotContent] = useState(null);
+  const [documentPageUrl, setDocumentPageUrl] = useState(null);
   const [deviceStatus, setDeviceStatus] = useState("checking");
   const [deviceError, setDeviceError] = useState("");
 
@@ -425,6 +426,32 @@ export default function EBookletViewerPage() {
     setActiveHotspot(null);
     setHotspotContent(null);
   }, [deviceStatus, instanceId, pageNumber, viewer.fetchPage]);
+
+  useEffect(() => {
+    if (viewer.page?.renderMode !== "pdf-document" || !viewer.page?.documentAssetId) {
+      setDocumentPageUrl(null);
+      return undefined;
+    }
+    let active = true;
+    let createdUrl = null;
+    setDocumentPageUrl(null);
+    viewer.fetchViewerDocumentBlobUrl(instanceId)
+      .then((url) => {
+        createdUrl = url;
+        if (active) {
+          setDocumentPageUrl(url);
+        } else {
+          URL.revokeObjectURL(url);
+        }
+      })
+      .catch(() => {
+        if (active) setDocumentPageUrl(null);
+      });
+    return () => {
+      active = false;
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [instanceId, viewer.fetchViewerDocumentBlobUrl, viewer.page?.documentAssetId, viewer.page?.renderMode]);
 
   useEffect(() => {
     const preventContextMenu = (event) => event.preventDefault();
@@ -475,7 +502,7 @@ export default function EBookletViewerPage() {
   }, [viewer]);
 
   const contentHotspot = hotspotContent || activeHotspot;
-  const pageUrl = viewer.page?.url || viewer.page?.pageUrl || viewer.page?.assetUrl || null;
+  const pageUrl = documentPageUrl || viewer.page?.url || viewer.page?.pageUrl || viewer.page?.assetUrl || null;
   const serverPage = viewer.page?.renderMode === "server-page" ? viewer.page : null;
 
   if (deviceStatus === "blocked") {
@@ -551,9 +578,8 @@ export default function EBookletViewerPage() {
               {pageUrl ? (
                 <iframe
                   title={t("viewer.pageFrameTitle", { page: pageNumber })}
-                  src={`${pageUrl}#toolbar=0&navpanes=0&scrollbar=0`}
+                  src={`${pageUrl}#page=${pageNumber}&toolbar=0&navpanes=0&scrollbar=0`}
                   className="absolute inset-0 h-full w-full border-0"
-                  sandbox=""
                 />
               ) : serverPage ? (
                 <div className="absolute inset-0 flex items-center justify-center bg-slate-50 p-8 text-center">


### PR DESCRIPTION
## What changed
- Added authenticated private viewer document endpoints for student and admin e-booklet viewers.
- Viewer page responses now advertise `renderMode: "pdf-document"` and `documentAssetId` when a delivered PDF exists.
- Frontend fetches the authorized PDF as a blob and renders the requested PDF page in the existing viewer iframe while preserving hotspot overlays.

## Why it changed
- Production browser proof showed viewer access/pages/hotspots worked, but the page body still showed the placeholder message instead of real PDF content.
- E-booklets intentionally use Kalima’s existing screenshot/payment-proof workflow; this PR does not add Paymob/PayTabs gateway logic.

## Proof/tests
- Clean deploy worktree from `origin/Rhiss`: `/tmp/kalima-pdf-render-deploy`.
- Backend: `npm test -- --runTestsByPath tests/e-booklet/e-booklet.service.spec.ts tests/e-booklet/e-booklet.routes.spec.ts --runInBand` → 2 suites passed, 74 tests passed.
- Backend: `npm run build` → `tsc` passed.
- Frontend: `npm run build` → Vite build passed.
- Static scan: no hardcoded secrets; no eval/exec/shell/deserialization matches.
- Independent reviewer verdict: APPROVED, no blocking correctness/security regressions.

## Risks/notes
- The iframe `sandbox` attribute was removed because native browser PDF rendering from a blob URL requires normal plugin/frame capabilities.
- Document access remains guarded by existing viewer/admin auth plus service-level access checks.
- Served file path is constrained to the configured e-booklet upload directory using `path.basename(storage_key)` and PDF MIME validation.

## Visual proof
- Pending production deploy/browser verification in this run: after deploy I will update this PR with production proof that page 1/page 2 render real PDF content with hotspots and 0 JS errors.
