### PR TITLE
fix: resolve e-booklet upload path in production

### DIFF
--- a/kalima-platform/backend/src/apps/store-api/services/e-booklet.service.ts
+++ b/kalima-platform/backend/src/apps/store-api/services/e-booklet.service.ts
@@ -12,10 +12,9 @@ import { generateInviteToken, hashInviteToken } from "../utils/e-booklet-token";
 
 type EBookletDb = PrismaClient | any;
 
-const E_BOOKLET_UPLOAD_DIR = path.resolve(
-  __dirname,
-  "../../../../uploads/e-booklets/private",
-);
+const E_BOOKLET_UPLOAD_DIR = process.env.E_BOOKLET_UPLOAD_DIR
+  ? path.resolve(process.env.E_BOOKLET_UPLOAD_DIR)
+  : path.resolve(process.cwd(), "uploads/e-booklets/private");
 const PASSCODE_BLOCK_MESSAGE = "Invalid e-booklet invite passcode.";
 const PASSCODE_MAX_FAILURES = 5;
 const PASSCODE_WINDOW_MS = 10 * 60 * 1000;


### PR DESCRIPTION
## What changed
- Fixes e-booklet private upload directory resolution in production containers.
- Uses `E_BOOKLET_UPLOAD_DIR` when provided, otherwise defaults to `process.cwd()/uploads/e-booklets/private` instead of a dist-relative path.

## Why
- Production backend was serving `/document` from `/app/dist/uploads/...`, but uploaded private booklet files are mounted at `/app/uploads/...`.
- This caused authorized viewer document requests to return 500/ENOENT after PDF rendering deploy.

## Verification
- `npm test -- --runTestsByPath tests/e-booklet/e-booklet.service.spec.ts tests/e-booklet/e-booklet.routes.spec.ts --runInBand`
- `npm run build`
- Independent review: APPROVED, no blockers.
