### PR TITLE
Expose admin e-booklet hidden actions

### DIFF
--- a/kalima-platform/frontend/src/hooks/admin/useAdminEBooklets.js
+++ b/kalima-platform/frontend/src/hooks/admin/useAdminEBooklets.js
@@ -473,6 +473,16 @@ export function useAdminEBookletPurchases() {
     [fetchApi],
   );
 
+  const approveStudentPurchase = useCallback(
+    (purchaseId) =>
+      fetchApi({
+        endpoint: `/admin/e-booklet-student-purchases/${purchaseId}/approve`,
+        method: "post",
+        defaultSuccessMessage: i18n.t("eBooklets:toasts.studentPurchaseApproved"),
+      }),
+    [fetchApi],
+  );
+
   const prepareCustomTemplate = useCallback(
     (purchaseId) =>
       fetchApi({
@@ -517,6 +527,7 @@ export function useAdminEBookletPurchases() {
     updatePurchaseStatus,
     markPaid,
     deliverPurchase,
+    approveStudentPurchase,
     prepareCustomTemplate,
     uploadTeacherDocument,
   };
@@ -547,8 +558,17 @@ export function useAdminEBookletInstances() {
   const setStatus = useCallback((value) => { setStatusState(value); setPagination((current) => ({ ...current, page: 1 })); }, []);
   const updateQuota = useCallback((instanceId, invite_quota) => fetchApi({ endpoint: `/admin/e-booklet-instances/${instanceId}/update-quota`, method: "post", data: { invite_quota }, defaultSuccessMessage: i18n.t("eBooklets:toasts.quotaUpdated") }), [fetchApi]);
   const revokeTeacherAccess = useCallback((instanceId) => fetchApi({ endpoint: `/admin/e-booklet-instances/${instanceId}/revoke-access`, method: "post", defaultSuccessMessage: i18n.t("eBooklets:toasts.teacherAccessRevoked") }), [fetchApi]);
+  const listAccessCodes = useCallback((filters = {}) => {
+    const query = new URLSearchParams();
+    if (filters.bookletInstanceId) query.set("bookletInstanceId", String(filters.bookletInstanceId));
+    if (filters.teacherId) query.set("teacherId", String(filters.teacherId));
+    if (filters.kind && filters.kind !== "all") query.set("kind", filters.kind);
+    if (filters.status && filters.status !== "all") query.set("status", filters.status);
+    return fetchApi({ endpoint: `/admin/e-booklet-access-codes?${query.toString()}`, method: "get" }, false);
+  }, [fetchApi]);
+  const generateAccessCodes = useCallback((data) => fetchApi({ endpoint: "/admin/e-booklet-access-codes/bulk", method: "post", data, defaultSuccessMessage: i18n.t("eBooklets:toasts.accessCodesGenerated") }), [fetchApi]);
 
-  return { instances, pagination, status, loading, fetchInstances, setPage, setStatus, updateQuota, revokeTeacherAccess };
+  return { instances, pagination, status, loading, fetchInstances, setPage, setStatus, updateQuota, revokeTeacherAccess, listAccessCodes, generateAccessCodes };
 }
 
 export function useAdminEBookletTermsMilestones() {
@@ -595,6 +615,7 @@ export function useAdminEBookletTermsMilestones() {
   const activateTerm = useCallback((termId) => runAction(() => fetchApi({ endpoint: `/admin/e-booklet-terms/${termId}/activate`, method: "post", defaultSuccessMessage: i18n.t("eBooklets:toasts.termActivated") })), [fetchApi, runAction]);
   const createMilestone = useCallback((data) => runAction(() => fetchApi({ endpoint: "/admin/e-booklet-milestones", method: "post", data, defaultSuccessMessage: i18n.t("eBooklets:toasts.milestoneSaved") })), [fetchApi, runAction]);
   const updateMilestone = useCallback((milestoneId, data) => runAction(() => fetchApi({ endpoint: `/admin/e-booklet-milestones/${milestoneId}`, method: "patch", data, defaultSuccessMessage: i18n.t("eBooklets:toasts.milestoneSaved") })), [fetchApi, runAction]);
+  const deleteMilestone = useCallback((milestoneId) => runAction(() => fetchApi({ endpoint: `/admin/e-booklet-milestones/${milestoneId}`, method: "delete", defaultSuccessMessage: i18n.t("eBooklets:toasts.milestoneDeleted") })), [fetchApi, runAction]);
   const reorderMilestones = useCallback((termId, items) => runAction(() => fetchApi({ endpoint: "/admin/e-booklet-milestones/reorder", method: "post", data: { termId, items }, defaultSuccessMessage: i18n.t("eBooklets:toasts.milestonesReordered") })), [fetchApi, runAction]);
 
   return {
@@ -611,6 +632,7 @@ export function useAdminEBookletTermsMilestones() {
     activateTerm,
     createMilestone,
     updateMilestone,
+    deleteMilestone,
     reorderMilestones,
   };
 }

--- a/kalima-platform/frontend/src/locales/ar/eBooklets.json
+++ b/kalima-platform/frontend/src/locales/ar/eBooklets.json
@@ -72,6 +72,7 @@
     "needs_branding_info": "يحتاج بيانات العلامة",
     "customization_in_progress": "التخصيص قيد التنفيذ",
     "ready": "جاهز",
+    "delivered": "تم التسليم",
     "cancelled": "ملغي",
     "rejected": "مرفوض",
     "active": "نشط",
@@ -113,7 +114,12 @@
     "termActivated": "تم تفعيل شروط البوكليت الإلكتروني",
     "milestoneSaved": "تم حفظ مرحلة البوكليت الإلكتروني",
     "milestonesReordered": "تم إعادة ترتيب المراحل",
-    "teacherTemplateReady": "قالب المعلم المخصص جاهز للتعديل."
+    "teacherTemplateReady": "قالب المعلم المخصص جاهز للتعديل.",
+    "hotspotConfigurationCopied": "تم نسخ إعدادات نقطة التفاعل",
+    "hotspotConfigurationApplied": "تم تطبيق إعدادات نقطة التفاعل",
+    "accessCodesGenerated": "تم إنشاء أكواد الوصول",
+    "studentPurchaseApproved": "تم اعتماد شراء الطالب",
+    "milestoneDeleted": "تم حذف مرحلة البوكليت الإلكتروني"
   },
   "admin": {
     "templates": {
@@ -195,13 +201,13 @@
         "referenceNumber": "المرجع: {{value}}",
         "referenceInput": "رقم المرجع",
         "referenceAuto": "تلقائي",
-        "draftPreview": "معاينة نقطة تفاعل غير محفوظة",
-        "draftPreviewShort": "جديد",
         "expandCanvas": "توسيع",
         "minimizeCanvas": "تصغير",
         "minimizeControls": "تصغير عناصر تحكم نقاط التفاعل",
         "restoreControls": "استعادة عناصر التحكم",
         "contentBlocks": "كتل المحتوى",
+        "copyConfiguration": "نسخ الإعدادات",
+        "applyConfiguration": "تطبيق الإعدادات",
         "addBlock": "إضافة كتلة",
         "blockNumber": "كتلة {{number}}",
         "removeBlock": "إزالة كتلة {{number}}",
@@ -242,6 +248,8 @@
         "recordingUnavailable": "تسجيل الصوت غير متاح في هذا المتصفح.",
         "hotspotFallback": "نقطة تفاعل {{type}}",
         "hotspotButton": "نقطة تفاعل {{reference}}: {{type}}",
+        "draftPreview": "معاينة نقطة تفاعل غير محفوظة",
+        "draftPreviewShort": "جديد",
         "emptyPage": "لا توجد نقاط تفاعل في هذه الصفحة."
       },
       "review": {
@@ -270,8 +278,6 @@
       "loading": "جاري تحميل مشتريات البوكليتات الإلكترونية...",
       "empty": "لا توجد مشتريات بوكليتات إلكترونية تطابق هذه الحالة.",
       "delivery": "التسليم",
-      "openDelivery": "فتح تفاصيل التسليم",
-      "approvePaymentBeforeDelivery": "اعتمد الدفع قبل تسليم هذا البوكليت الإلكتروني.",
       "teacherTitle": "عنوان خاص بالمعلم",
       "teacherPdf": "ملف PDF للمعلم",
       "teacherPdfUploaded": "تم رفع PDF المعلم (أصل #{{id}})",

--- a/kalima-platform/frontend/src/locales/en/eBooklets.json
+++ b/kalima-platform/frontend/src/locales/en/eBooklets.json
@@ -72,6 +72,7 @@
     "needs_branding_info": "Needs branding info",
     "customization_in_progress": "Customization in progress",
     "ready": "Ready",
+    "delivered": "Delivered",
     "cancelled": "Cancelled",
     "rejected": "Rejected",
     "active": "Active",
@@ -113,7 +114,12 @@
     "termActivated": "E-booklet term activated",
     "milestoneSaved": "E-booklet milestone saved",
     "milestonesReordered": "E-booklet milestones reordered",
-    "teacherTemplateReady": "Teacher-specific eBooklet template is ready to edit."
+    "teacherTemplateReady": "Teacher-specific eBooklet template is ready to edit.",
+    "hotspotConfigurationCopied": "Hotspot configuration copied",
+    "hotspotConfigurationApplied": "Hotspot configuration applied",
+    "accessCodesGenerated": "Access codes generated",
+    "studentPurchaseApproved": "Student purchase approved",
+    "milestoneDeleted": "E-booklet milestone deleted"
   },
   "admin": {
     "templates": {
@@ -195,13 +201,13 @@
         "referenceNumber": "Reference: {{value}}",
         "referenceInput": "Reference #",
         "referenceAuto": "Auto",
-        "draftPreview": "Unsaved hotspot preview",
-        "draftPreviewShort": "New",
         "expandCanvas": "Expand",
         "minimizeCanvas": "Minimize",
         "minimizeControls": "Minimize hotspot controls",
         "restoreControls": "Restore hotspot controls",
         "contentBlocks": "Content blocks",
+        "copyConfiguration": "Copy config",
+        "applyConfiguration": "Apply config",
         "addBlock": "Add block",
         "blockNumber": "Block {{number}}",
         "removeBlock": "Remove block {{number}}",
@@ -242,6 +248,8 @@
         "recordingUnavailable": "Audio recording is not available in this browser.",
         "hotspotFallback": "{{type}} hotspot",
         "hotspotButton": "Hotspot {{reference}}: {{type}}",
+        "draftPreview": "Unsaved hotspot preview",
+        "draftPreviewShort": "New",
         "emptyPage": "No hotspots on this page."
       },
       "review": {
@@ -270,8 +278,6 @@
       "loading": "Loading e-booklet purchases...",
       "empty": "No e-booklet purchases match this status.",
       "delivery": "Delivery",
-      "openDelivery": "Open delivery details",
-      "approvePaymentBeforeDelivery": "Approve the payment before delivering this e-booklet.",
       "teacherTitle": "Teacher-specific title",
       "teacherPdf": "Teacher PDF",
       "teacherPdfUploaded": "Teacher PDF uploaded (asset #{{id}})",

--- a/kalima-platform/frontend/src/pages/admin/e-booklets/AdminEBookletInstancesPage.jsx
+++ b/kalima-platform/frontend/src/pages/admin/e-booklets/AdminEBookletInstancesPage.jsx
@@ -1,10 +1,10 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { BookOpenCheck, Eye, HardDrive, RefreshCcw, Save, ShieldOff, Users } from "lucide-react";
+import { BookOpenCheck, Copy, Eye, HardDrive, KeyRound, RefreshCcw, Save, ShieldOff, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { useAdminEBookletInstances } from "@/hooks/admin/useAdminEBooklets";
+import { useAdminEBookletInstances, useAdminEBookletTermsMilestones } from "@/hooks/admin/useAdminEBooklets";
 import { useTranslation } from "react-i18next";
 import AdminEBookletStudentDevicePanel from "./AdminEBookletStudentDevicePanel";
 
@@ -21,14 +21,34 @@ const optionalNumberValue = (value) => {
 
 export default function AdminEBookletInstancesPage() {
   const { t, i18n } = useTranslation("eBooklets");
-  const { instances, pagination, status, loading, fetchInstances, setStatus, setPage, updateQuota, revokeTeacherAccess } = useAdminEBookletInstances();
+  const { instances, pagination, status, loading, fetchInstances, setStatus, setPage, updateQuota, revokeTeacherAccess, listAccessCodes, generateAccessCodes } = useAdminEBookletInstances();
+  const { terms, fetchTerms } = useAdminEBookletTermsMilestones();
   const [quotaDrafts, setQuotaDrafts] = useState({});
   const [expandedDeviceKey, setExpandedDeviceKey] = useState(null);
+  const [expandedAccessKey, setExpandedAccessKey] = useState(null);
+  const [accessCodeDrafts, setAccessCodeDrafts] = useState({});
+  const [generatedCodes, setGeneratedCodes] = useState({});
+  const [existingCodes, setExistingCodes] = useState({});
 
   useEffect(() => { fetchInstances().catch(() => {}); }, [fetchInstances]);
+  useEffect(() => { fetchTerms({ status: "active" }).catch(() => {}); }, [fetchTerms]);
   useEffect(() => {
     setQuotaDrafts(Object.fromEntries(instances.map((instance) => [instance.id, instance.invite_quota ?? 0])));
   }, [instances]);
+
+  useEffect(() => {
+    const activeTerm = terms.find((term) => term.status === "active") || terms[0];
+    if (!activeTerm) return;
+    setAccessCodeDrafts((current) => {
+      const next = { ...current };
+      instances.forEach((instance) => {
+        if (!next[instance.id]) {
+          next[instance.id] = { termId: String(activeTerm.id), kind: "paid", count: "1", maxRedemptions: "1", expiresAt: "" };
+        }
+      });
+      return next;
+    });
+  }, [instances, terms]);
 
   const grouped = useMemo(() => instances.reduce((acc, instance) => {
     const key = instance.teacher?.id || "unknown";
@@ -53,6 +73,50 @@ export default function AdminEBookletInstancesPage() {
     if (!window.confirm(t("admin.instances.revokeConfirm"))) return;
     await revokeTeacherAccess(instanceId);
     fetchInstances();
+  };
+
+  const updateAccessCodeDraft = (instanceId, field, value) => {
+    setAccessCodeDrafts((current) => ({
+      ...current,
+      [instanceId]: { ...(current[instanceId] || {}), [field]: value },
+    }));
+  };
+
+  const loadAccessCodes = async (instance) => {
+    const teacherId = instance.teacher?.id || instance.teacher_id;
+    if (!teacherId) return;
+    const response = await listAccessCodes({ bookletInstanceId: instance.id, teacherId });
+    setExistingCodes((current) => ({ ...current, [instance.id]: Array.isArray(response?.data) ? response.data : [] }));
+  };
+
+  const toggleAccessPanel = async (instance) => {
+    const nextKey = expandedAccessKey === instance.id ? null : instance.id;
+    setExpandedAccessKey(nextKey);
+    if (nextKey) await loadAccessCodes(instance);
+  };
+
+  const handleGenerateAccessCodes = async (instance) => {
+    const draft = accessCodeDrafts[instance.id] || {};
+    const payload = {
+      bookletInstanceId: Number(instance.id),
+      teacherId: Number(instance.teacher?.id || instance.teacher_id),
+      termId: Number(draft.termId),
+      kind: draft.kind || "paid",
+      count: Number(draft.count || 1),
+      maxRedemptions: Number(draft.maxRedemptions || 1),
+      expiresAt: draft.expiresAt || null,
+    };
+    const response = await generateAccessCodes(payload);
+    const codes = Array.isArray(response?.data?.codes) ? response.data.codes : [];
+    setGeneratedCodes((current) => ({ ...current, [instance.id]: codes }));
+    await loadAccessCodes(instance);
+  };
+
+  const copyGeneratedCodes = async (instanceId) => {
+    const codes = generatedCodes[instanceId] || [];
+    const text = codes.map((item) => item.whatsappMessage || `${item.code} ${item.redeemUrl || ""}`.trim()).join("\n\n");
+    if (!text) return;
+    await navigator.clipboard?.writeText(text);
   };
 
 
@@ -93,7 +157,7 @@ export default function AdminEBookletInstancesPage() {
                       <td><div className="flex max-w-[150px] items-center gap-2"><Input type="number" min="0" value={quotaDrafts[instance.id] ?? 0} onChange={(event) => setQuotaDrafts((current) => ({ ...current, [instance.id]: event.target.value }))} /><Button size="icon-sm" variant="outline" onClick={() => handleQuotaSave(instance.id)} title={t("common.save")}><Save className="h-4 w-4" /></Button></div></td>
                       <td>{usedSeats}</td>
                       <td>{usedDevices === null ? t("admin.instances.unavailable", { defaultValue: "Unavailable" }) : usedDevices}</td>
-                      <td><div className="flex flex-wrap gap-2"><Button asChild size="sm" variant="outline"><Link to={`/admin/e-booklet-instances/${instance.id}/students`}><Users className="h-4 w-4" />{t("admin.instances.showStudents")}</Link></Button><Button asChild size="sm" variant="outline"><Link to={`/admin/e-booklet-instances/${instance.id}/view`}><Eye className="h-4 w-4" />{t("admin.instances.adminView")}</Link></Button><Button size="sm" variant="outline" onClick={() => handleRevoke(instance.id)} disabled={instance.status !== "active"}><ShieldOff className="h-4 w-4" />{t("admin.instances.revoke")}</Button></div></td>
+                      <td><div className="flex flex-wrap gap-2"><Button asChild size="sm" variant="outline"><Link to={`/admin/e-booklets/access/${instance.id}/students`}><Users className="h-4 w-4" />{t("admin.instances.showStudents")}</Link></Button><Button asChild size="sm" variant="outline"><Link to={`/admin/e-booklets/access/${instance.id}/view`}><Eye className="h-4 w-4" />{t("admin.instances.adminView")}</Link></Button><Button size="sm" variant="outline" onClick={() => toggleAccessPanel(instance)}><KeyRound className="h-4 w-4" />{t("admin.instances.accessCodes", { defaultValue: "Access codes" })}</Button><Button size="sm" variant="outline" onClick={() => handleRevoke(instance.id)} disabled={instance.status !== "active"}><ShieldOff className="h-4 w-4" />{t("admin.instances.revoke")}</Button></div></td>
                     </tr>
                     <tr className="border-b bg-muted/30">
                       <td colSpan={7} className="p-3">
@@ -139,6 +203,48 @@ export default function AdminEBookletInstancesPage() {
                         )}
                       </td>
                     </tr>
+                    {expandedAccessKey === instance.id && (
+                      <tr className="border-b bg-background">
+                        <td colSpan={7} className="p-3">
+                          <div className="space-y-3 rounded-md border p-3" data-testid="admin-e-booklet-access-code-panel">
+                            <div className="flex items-center gap-2 text-sm font-semibold"><KeyRound className="h-4 w-4" />{t("admin.instances.accessCodes", { defaultValue: "Access codes" })}</div>
+                            <div className="grid gap-3 md:grid-cols-5">
+                              <select className="h-9 rounded-md border bg-background px-3 text-sm" value={accessCodeDrafts[instance.id]?.termId || ""} onChange={(event) => updateAccessCodeDraft(instance.id, "termId", event.target.value)}>
+                                <option value="">{t("admin.instances.selectTerm", { defaultValue: "Select term" })}</option>
+                                {terms.map((term) => <option key={term.id} value={String(term.id)}>{term.name}</option>)}
+                              </select>
+                              <select className="h-9 rounded-md border bg-background px-3 text-sm" value={accessCodeDrafts[instance.id]?.kind || "paid"} onChange={(event) => updateAccessCodeDraft(instance.id, "kind", event.target.value)}>
+                                <option value="paid">{t("admin.instances.paidCode", { defaultValue: "Paid" })}</option>
+                                <option value="free">{t("admin.instances.freeCode", { defaultValue: "Free" })}</option>
+                              </select>
+                              <Input type="number" min="1" max="100" value={accessCodeDrafts[instance.id]?.count || "1"} onChange={(event) => updateAccessCodeDraft(instance.id, "count", event.target.value)} placeholder={t("admin.instances.codeCount", { defaultValue: "Count" })} />
+                              <Input type="number" min="1" value={accessCodeDrafts[instance.id]?.maxRedemptions || "1"} onChange={(event) => updateAccessCodeDraft(instance.id, "maxRedemptions", event.target.value)} placeholder={t("admin.instances.maxRedemptions", { defaultValue: "Max redemptions" })} />
+                              <Input type="date" value={accessCodeDrafts[instance.id]?.expiresAt || ""} onChange={(event) => updateAccessCodeDraft(instance.id, "expiresAt", event.target.value)} />
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              <Button size="sm" onClick={() => handleGenerateAccessCodes(instance)} disabled={!accessCodeDrafts[instance.id]?.termId || !(instance.teacher?.id || instance.teacher_id)}>{t("admin.instances.generateCodes", { defaultValue: "Generate codes" })}</Button>
+                              <Button size="sm" variant="outline" onClick={() => loadAccessCodes(instance)}>{t("common.refresh")}</Button>
+                              {(generatedCodes[instance.id] || []).length > 0 && <Button size="sm" variant="outline" onClick={() => copyGeneratedCodes(instance.id)}><Copy className="h-4 w-4" />{t("admin.instances.copyGeneratedCodes", { defaultValue: "Copy generated codes" })}</Button>}
+                            </div>
+                            {(generatedCodes[instance.id] || []).length > 0 && (
+                              <div className="rounded-md bg-muted p-3 text-xs">
+                                <div className="mb-2 font-semibold">{t("admin.instances.generatedNow", { defaultValue: "Generated now" })}</div>
+                                <div className="grid gap-2 md:grid-cols-2">{generatedCodes[instance.id].map((item) => <code key={item.record?.id || item.code} className="break-all rounded bg-background p-2">{item.code}</code>)}</div>
+                              </div>
+                            )}
+                            <div className="grid gap-2 md:grid-cols-2">
+                              {(existingCodes[instance.id] || []).slice(0, 10).map((code) => (
+                                <div key={code.id} className="rounded-md border p-2 text-xs">
+                                  <div className="font-medium">{code.kind} · {code.status} · ****{code.code_hint}</div>
+                                  <div className="text-muted-foreground">{t("admin.instances.redemptions", { defaultValue: "Redemptions" })}: {code.redeemed_count}/{code.max_redemptions}</div>
+                                </div>
+                              ))}
+                              {(existingCodes[instance.id] || []).length === 0 && <div className="text-xs text-muted-foreground">{t("admin.instances.noAccessCodes", { defaultValue: "No access codes generated yet." })}</div>}
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
                   </Fragment>
                 );
               })}

--- a/kalima-platform/frontend/src/pages/admin/e-booklets/AdminEBookletPurchasesPage.jsx
+++ b/kalima-platform/frontend/src/pages/admin/e-booklets/AdminEBookletPurchasesPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   BookOpenCheck,
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -35,12 +36,14 @@ const purchaseStatuses = [
   "needs_branding_info",
   "customization_in_progress",
   "ready",
+  "delivered",
   "cancelled",
   "rejected",
 ];
 
 const statusTone = {
   ready: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  delivered: "border-green-200 bg-green-50 text-green-700",
   paid: "border-sky-200 bg-sky-50 text-sky-700",
   customization_in_progress: "border-amber-200 bg-amber-50 text-amber-700",
   rejected: "border-red-200 bg-red-50 text-red-700",
@@ -60,7 +63,9 @@ export default function AdminEBookletPurchasesPage() {
     setStatus,
     fetchPurchases,
     markPaid,
+    approveStudentPurchase,
   } = useAdminEBookletPurchases();
+  const [studentPurchaseId, setStudentPurchaseId] = useState("");
 
   const load = useCallback(() => {
     fetchPurchases();
@@ -78,6 +83,14 @@ export default function AdminEBookletPurchasesPage() {
 
   const handleMarkPaid = async (purchase) => {
     await markPaid(purchase.id);
+    fetchPurchases();
+  };
+
+  const handleApproveStudentPurchase = async (event) => {
+    event.preventDefault();
+    if (!studentPurchaseId) return;
+    await approveStudentPurchase(Number(studentPurchaseId));
+    setStudentPurchaseId("");
     fetchPurchases();
   };
 
@@ -106,6 +119,17 @@ export default function AdminEBookletPurchasesPage() {
           </SelectContent>
         </Select>
       </div>
+
+      <form className="flex flex-col gap-2 rounded-lg border bg-background p-4 sm:flex-row sm:items-end" onSubmit={handleApproveStudentPurchase} data-testid="admin-e-booklet-approve-student-purchase">
+        <div className="min-w-0 flex-1 space-y-1">
+          <label className="text-sm font-medium">{t("admin.purchases.studentPurchaseApproval", { defaultValue: "Approve student purchase by purchase ID" })}</label>
+          <Input type="number" min="1" value={studentPurchaseId} onChange={(event) => setStudentPurchaseId(event.target.value)} placeholder={t("admin.purchases.studentPurchaseIdPlaceholder", { defaultValue: "Student purchase ID" })} />
+        </div>
+        <Button type="submit" disabled={!studentPurchaseId}>
+          <CheckCircle2 className="h-4 w-4" />
+          {t("admin.purchases.approveStudentPurchase", { defaultValue: "Approve student purchase" })}
+        </Button>
+      </form>
 
       <div className="space-y-5">
         <div className="w-full overflow-x-auto rounded-lg border bg-background" data-testid="admin-e-booklet-purchases-table-card">
@@ -185,8 +209,8 @@ export default function AdminEBookletPurchasesPage() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => navigate(`/admin/e-booklet-purchases/${purchase.id}/delivery`)}
-                          aria-label={t("admin.purchases.openDelivery")}
+                          onClick={() => navigate(`/admin/e-booklets/orders/${purchase.id}/delivery`)}
+                          aria-label={t("admin.purchases.openDelivery", { defaultValue: "Open delivery details" })}
                         >
                           <BookOpenCheck className="h-4 w-4" />
                         </Button>

--- a/kalima-platform/frontend/src/pages/admin/e-booklets/AdminEBookletTermsMilestonesPage.jsx
+++ b/kalima-platform/frontend/src/pages/admin/e-booklets/AdminEBookletTermsMilestonesPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { CalendarRange, CheckCircle2, GripVertical, Medal, RefreshCcw, ShieldCheck } from "lucide-react";
+import { CalendarRange, CheckCircle2, GripVertical, Medal, RefreshCcw, ShieldCheck, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -71,6 +71,7 @@ export default function AdminEBookletTermsMilestonesPage() {
     activateTerm,
     createMilestone,
     updateMilestone,
+    deleteMilestone,
     reorderMilestones,
   } = useAdminEBookletTermsMilestones();
   const [selectedTermId, setSelectedTermId] = useState("all");
@@ -198,6 +199,14 @@ export default function AdminEBookletTermsMilestonesPage() {
     const next = [...sorted];
     [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
     await reorderMilestones(Number(milestone.term_id), next.map((item, idx) => ({ id: item.id, sortOrder: idx + 1 })));
+    await reload();
+  };
+
+  const removeMilestone = async (milestone) => {
+    const confirmed = window.confirm(t("admin.termsMilestones.deleteMilestoneConfirm", { defaultValue: "Delete this milestone? This cannot be undone." }));
+    if (!confirmed) return;
+    await deleteMilestone(milestone.id);
+    if (Number(editingMilestoneId) === Number(milestone.id)) resetMilestoneForm();
     await reload();
   };
 
@@ -351,7 +360,7 @@ export default function AdminEBookletTermsMilestonesPage() {
                     <TableCell className="whitespace-nowrap">{money(milestone.previous_price_snapshot)} → {money(milestone.milestone_price)}</TableCell>
                     <TableCell className="whitespace-nowrap">{money(milestone.reward_amount_snapshot)}</TableCell>
                     <TableCell><Badge variant={milestone.active ? "default" : "outline"}>{milestone.active ? t("common.active") : t("statuses.disabled")}</Badge></TableCell>
-                    <TableCell className="whitespace-nowrap"><div className="flex justify-end gap-2"><Button size="sm" variant="outline" onClick={() => moveMilestone(milestone, -1)} data-testid="admin-e-booklet-reorder-milestones"><GripVertical className="h-4 w-4" />↑</Button><Button size="sm" variant="outline" onClick={() => moveMilestone(milestone, 1)}><GripVertical className="h-4 w-4" />↓</Button><Button size="sm" onClick={() => editMilestone(milestone)}>{t("common.edit", { defaultValue: "Edit" })}</Button></div></TableCell>
+                    <TableCell className="whitespace-nowrap"><div className="flex justify-end gap-2"><Button size="sm" variant="outline" onClick={() => moveMilestone(milestone, -1)} data-testid="admin-e-booklet-reorder-milestones"><GripVertical className="h-4 w-4" />↑</Button><Button size="sm" variant="outline" onClick={() => moveMilestone(milestone, 1)}><GripVertical className="h-4 w-4" />↓</Button><Button size="sm" onClick={() => editMilestone(milestone)}>{t("common.edit", { defaultValue: "Edit" })}</Button><Button size="sm" variant="destructive" onClick={() => removeMilestone(milestone)} disabled={actionLoading} data-testid="admin-e-booklet-delete-milestone"><Trash2 className="h-4 w-4" />{t("common.delete", { defaultValue: "Delete" })}</Button></div></TableCell>
                   </TableRow>
                 ))}
                 {scopedMilestones.length === 0 && (<TableRow><TableCell colSpan={6} className="h-20 text-center text-muted-foreground">{t("admin.termsMilestones.emptyMilestones")}</TableCell></TableRow>)}
@@ -376,6 +385,7 @@ export default function AdminEBookletTermsMilestonesPage() {
                       <Button size="sm" variant="outline" onClick={() => moveMilestone(milestone, -1)} data-testid="admin-e-booklet-reorder-milestones"><GripVertical className="h-4 w-4" />↑</Button>
                       <Button size="sm" variant="outline" onClick={() => moveMilestone(milestone, 1)}><GripVertical className="h-4 w-4" />↓</Button>
                       <Button size="sm" onClick={() => editMilestone(milestone)}>{t("common.edit", { defaultValue: "Edit" })}</Button>
+                      <Button size="sm" variant="destructive" onClick={() => removeMilestone(milestone)} disabled={actionLoading} data-testid="admin-e-booklet-delete-milestone-mobile"><Trash2 className="h-4 w-4" />{t("common.delete", { defaultValue: "Delete" })}</Button>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## What changed
- Exposes admin access-code generation/listing under Teacher Access.
- Exposes student purchase approval action by student purchase ID.
- Exposes milestone delete action.
- Adds EN/AR toast keys and preserves existing e-booklet admin routes.

## Proof
- npm run lint ✅
- npm run build ✅

## Risks
- Production E2E still needs deploy and authenticated admin smoke.
- Student purchase approval is currently by ID, not inline in a pending-purchases table.