### PR TITLE
Fix WhatsApp QR initialization recovery

### DIFF
--- a/kalima-platform/backend/src/apps/store-api/services/whatsapp.service.spec.ts
+++ b/kalima-platform/backend/src/apps/store-api/services/whatsapp.service.spec.ts
@@ -1,0 +1,21 @@
+jest.mock("../../../libs/whatsapp/client", () => ({
+  baileysClient: {
+    status: "qr_pending",
+    phoneNumber: null,
+    qrCode: "test-qr-value",
+    sendMessage: jest.fn(),
+    logout: jest.fn(),
+  },
+}));
+
+import { whatsappService } from "./whatsapp.service";
+
+describe("whatsappService.getStatus", () => {
+  it("includes the current QR so clients that missed the socket event can recover", () => {
+    expect(whatsappService.getStatus()).toEqual({
+      status: "qr_pending",
+      whatsapp_sending_number: null,
+      qr: "test-qr-value",
+    });
+  });
+});

--- a/kalima-platform/backend/src/apps/store-api/services/whatsapp.service.ts
+++ b/kalima-platform/backend/src/apps/store-api/services/whatsapp.service.ts
@@ -19,6 +19,7 @@ class WhatsAppService {
       status: baileysClient.status,
       whatsapp_sending_number:
         baileysClient.status === "ready" ? baileysClient.phoneNumber : null,
+      qr: baileysClient.qrCode,
     };
   }
 

--- a/kalima-platform/backend/src/libs/socket/setupStoreSocket.ts
+++ b/kalima-platform/backend/src/libs/socket/setupStoreSocket.ts
@@ -104,7 +104,16 @@ export function setupStoreSocket(httpServer: HttpServer): Server {
               : baileysClient.status,
           });
           console.log(`[Socket] Initializing WhatsApp Baileys Client...`);
-          await baileysClient.initialize(whatsappCallbacks);
+          try {
+            await baileysClient.initialize(whatsappCallbacks);
+          } catch (error) {
+            const reason = error instanceof Error ? error.message : "Unknown initialization error";
+            console.error(`[Socket] Failed to initialize WhatsApp client:`, error);
+            socket.emit("whatsappAuthFailed", {
+              status: "rejected",
+              reason,
+            });
+          }
         });
       }
     } catch (err: any) {

--- a/kalima-platform/backend/src/libs/whatsapp/client.ts
+++ b/kalima-platform/backend/src/libs/whatsapp/client.ts
@@ -49,6 +49,7 @@ export class BaileysClient {
   private _status: WhatsAppStatus = "disconnected";
   private _phoneNumber: string | null = null;
   private connectPromise: Promise<void> | null = null;
+  private _qrCode: string | null = null;
   private reconnectTimer: NodeJS.Timeout | null = null;
   private reconnectAttempt = 0;
   private generation = 0;
@@ -64,6 +65,7 @@ export class BaileysClient {
 
   get status() { return this._status; }
   get phoneNumber() { return this._phoneNumber; }
+  get qrCode() { return this._qrCode; }
 
   async restore(callbacks: BaileysCallbacks): Promise<boolean> {
     this.callbacks = callbacks;
@@ -95,6 +97,7 @@ export class BaileysClient {
 
   private setStatus(status: WhatsAppStatus): void {
     this._status = status;
+    if (status !== "qr_pending") this._qrCode = null;
     this.callbacks?.onStatusChange?.(status);
   }
 
@@ -145,6 +148,7 @@ export class BaileysClient {
       const { connection, lastDisconnect, qr } = update;
 
       if (qr) {
+        this._qrCode = qr;
         this.setStatus("qr_pending");
         this.callbacks?.onQr(qr);
       }

--- a/kalima-platform/frontend/src/hooks/admin/useWhatsappStatus.js
+++ b/kalima-platform/frontend/src/hooks/admin/useWhatsappStatus.js
@@ -15,8 +15,11 @@ export const useWhatsappStatus = () => {
     const fetchStatus = useCallback(async () => {
         try {
             const response = await axiosInstance.get('/admin/whatsapp/status');
-            const { status: currentStatus, whatsapp_sending_number } = response.data.data;
-            setStatus(currentStatus);
+            const { status: currentStatus, whatsapp_sending_number, qr } = response.data.data;
+            setQrCodeStr(qr || null);
+            // A qr_pending state without a QR is stale and cannot make progress.
+            // Present a retryable failure instead of an infinite initialization screen.
+            setStatus(currentStatus === 'qr_pending' && !qr ? 'failed' : currentStatus);
             setSendingNumber(whatsapp_sending_number);
         } catch (error) {
             console.error('Failed to fetch WhatsApp status:', error);


### PR DESCRIPTION
## Summary
- cache the latest WhatsApp QR so admins recover after missing the socket event
- return the cached QR from the status endpoint
- turn stale QR-pending states and initialization errors into actionable retry states
- preserve the existing hardened reconnect and logout lifecycle

## Validation
- 29 backend suites passed, 323 tests total
- backend TypeScript build passed
- frontend production build passed
- local UI generated a QR and changed to the refresh state
