### PR TITLE
Harden Kalima for campaign traffic

### DIFF
--- a/kalima-platform/backend/package-lock.json
+++ b/kalima-platform/backend/package-lock.json
@@ -53,6 +53,7 @@
         "pg": "^8.18.0",
         "pino": "^10.3.1",
         "prisma": "^7.4.0",
+        "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "reflect-metadata": "^0.2.2",
         "resend": "^4.4.1",
@@ -4323,6 +4324,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -9969,6 +9976,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11403,6 +11423,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
     },
     "node_modules/teeny-request": {
       "version": "9.0.0",

--- a/kalima-platform/backend/package.json
+++ b/kalima-platform/backend/package.json
@@ -75,6 +75,7 @@
     "pg": "^8.18.0",
     "pino": "^10.3.1",
     "prisma": "^7.4.0",
+    "prom-client": "^15.1.3",
     "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.2",
     "resend": "^4.4.1",

--- a/kalima-platform/backend/src/libs/metrics.spec.ts
+++ b/kalima-platform/backend/src/libs/metrics.spec.ts
@@ -1,0 +1,108 @@
+import express from "express";
+import request from "supertest";
+import {
+  httpMetricsMiddleware,
+  metricsAccessMiddleware,
+  metricsHandler,
+  metricsRegistry,
+} from "./metrics";
+
+function buildApp() {
+  const app = express();
+
+  app.use(httpMetricsMiddleware);
+  app.get("/metrics", metricsAccessMiddleware, metricsHandler);
+  app.get("/api/v2/users/:userId/orders/:orderId", (_req, res) => {
+    res.json({ ok: true });
+  });
+  app.get("/api/v2/fail/:id", (_req, res) => {
+    res.status(500).json({ ok: false });
+  });
+
+  return app;
+}
+
+describe("Prometheus metrics", () => {
+  const originalMetricsToken = process.env.METRICS_TOKEN;
+  const originalAllowLocalhost = process.env.METRICS_ALLOW_LOCALHOST;
+
+  beforeEach(() => {
+    delete process.env.METRICS_TOKEN;
+    delete process.env.METRICS_ALLOW_LOCALHOST;
+    metricsRegistry.resetMetrics();
+  });
+
+  afterAll(() => {
+    if (originalMetricsToken === undefined) {
+      delete process.env.METRICS_TOKEN;
+    } else {
+      process.env.METRICS_TOKEN = originalMetricsToken;
+    }
+
+    if (originalAllowLocalhost === undefined) {
+      delete process.env.METRICS_ALLOW_LOCALHOST;
+    } else {
+      process.env.METRICS_ALLOW_LOCALHOST = originalAllowLocalhost;
+    }
+  });
+
+  it("denies /metrics by default", async () => {
+    const app = buildApp();
+
+    const response = await request(app).get("/metrics");
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      success: false,
+      message: "Metrics endpoint is not available from this client",
+    });
+  });
+
+  it("allows /metrics with the configured bearer token and exposes default metrics", async () => {
+    process.env.METRICS_TOKEN = "test-metrics-token";
+    const app = buildApp();
+
+    const response = await request(app)
+      .get("/metrics")
+      .set("Authorization", "Bearer test-metrics-token");
+
+    expect(response.status).toBe(200);
+    expect(response.header["content-type"]).toContain("text/plain");
+    expect(response.text).toContain("# HELP kalima_process_cpu_user_seconds_total");
+    expect(response.text).toContain("# HELP kalima_http_requests_total");
+  });
+
+  it("allows /metrics from localhost only when explicitly enabled", async () => {
+    process.env.METRICS_ALLOW_LOCALHOST = "true";
+    const app = buildApp();
+
+    const response = await request(app).get("/metrics");
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain("# HELP kalima_http_request_duration_seconds");
+  });
+
+  it("records HTTP metrics with low-cardinality route labels instead of raw URLs", async () => {
+    process.env.METRICS_TOKEN = "test-metrics-token";
+    const app = buildApp();
+
+    await request(app).get("/api/v2/users/alice-secret/orders/order-123?token=hidden").expect(200);
+    await request(app).get("/api/v2/fail/private-id").expect(500);
+
+    const response = await request(app)
+      .get("/metrics")
+      .set("x-metrics-token", "test-metrics-token")
+      .expect(200);
+
+    expect(response.text).toContain(
+      'kalima_http_requests_total{method="GET",route="/api/v2/users/:userId/orders/:orderId",status_code="200"} 1',
+    );
+    expect(response.text).toContain(
+      'kalima_http_requests_total{method="GET",route="/api/v2/fail/:id",status_code="500"} 1',
+    );
+    expect(response.text).not.toContain("alice-secret");
+    expect(response.text).not.toContain("order-123");
+    expect(response.text).not.toContain("hidden");
+    expect(response.text).not.toContain("/metrics");
+  });
+});

--- a/kalima-platform/backend/src/libs/metrics.ts
+++ b/kalima-platform/backend/src/libs/metrics.ts
@@ -1,0 +1,144 @@
+import type { NextFunction, Request, Response } from "express";
+import {
+  collectDefaultMetrics,
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+} from "prom-client";
+
+const METRICS_ROUTE = "/metrics";
+const UNKNOWN_ROUTE = "unmatched";
+
+export const metricsRegistry = new Registry();
+
+collectDefaultMetrics({
+  prefix: "kalima_",
+  register: metricsRegistry,
+});
+
+export const httpRequestDurationSeconds = new Histogram({
+  name: "kalima_http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds.",
+  labelNames: ["method", "route", "status_code"] as const,
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [metricsRegistry],
+});
+
+export const httpRequestsTotal = new Counter({
+  name: "kalima_http_requests_total",
+  help: "Total number of completed HTTP requests.",
+  labelNames: ["method", "route", "status_code"] as const,
+  registers: [metricsRegistry],
+});
+
+export const httpRequestsInFlight = new Gauge({
+  name: "kalima_http_requests_in_flight",
+  help: "Number of HTTP requests currently in flight.",
+  labelNames: ["method"] as const,
+  registers: [metricsRegistry],
+});
+
+function normalizeMethod(method: string): string {
+  return method.toUpperCase();
+}
+
+function routePath(req: Request): string {
+  const route = req.route?.path;
+  const routePattern = Array.isArray(route) ? route[0] : route;
+
+  if (typeof routePattern === "string" && routePattern.length > 0) {
+    return `${req.baseUrl || ""}${routePattern}` || "/";
+  }
+
+  if (req.baseUrl) {
+    return req.baseUrl;
+  }
+
+  return UNKNOWN_ROUTE;
+}
+
+function isMetricsRequest(req: Request): boolean {
+  return req.path === METRICS_ROUTE || req.originalUrl.split("?")[0] === METRICS_ROUTE;
+}
+
+export function httpMetricsMiddleware(req: Request, res: Response, next: NextFunction): void {
+  if (isMetricsRequest(req)) {
+    next();
+    return;
+  }
+
+  const method = normalizeMethod(req.method);
+  const start = process.hrtime.bigint();
+  let completed = false;
+
+  httpRequestsInFlight.inc({ method });
+
+  const finish = () => {
+    if (completed) {
+      return;
+    }
+
+    completed = true;
+    const route = routePath(req);
+    const statusCode = String(res.statusCode || 0);
+    const durationSeconds = Number(process.hrtime.bigint() - start) / 1_000_000_000;
+
+    httpRequestsInFlight.dec({ method });
+    httpRequestsTotal.inc({ method, route, status_code: statusCode });
+    httpRequestDurationSeconds.observe({ method, route, status_code: statusCode }, durationSeconds);
+  };
+
+  res.once("finish", finish);
+  res.once("close", finish);
+
+  next();
+}
+
+function isLoopbackAddress(ip: string | undefined): boolean {
+  if (!ip) {
+    return false;
+  }
+
+  return ip === "127.0.0.1"
+    || ip === "::1"
+    || ip === "::ffff:127.0.0.1"
+    || ip.startsWith("127.");
+}
+
+function hasValidMetricsToken(req: Request): boolean {
+  const expectedToken = process.env.METRICS_TOKEN;
+
+  if (!expectedToken) {
+    return false;
+  }
+
+  const authHeader = req.header("authorization") || "";
+  const bearerToken = authHeader.toLowerCase().startsWith("bearer ")
+    ? authHeader.slice(7)
+    : undefined;
+  const headerToken = req.header("x-metrics-token");
+
+  return bearerToken === expectedToken || headerToken === expectedToken;
+}
+
+function isLocalMetricsAccessAllowed(req: Request): boolean {
+  return process.env.METRICS_ALLOW_LOCALHOST === "true" && isLoopbackAddress(req.ip);
+}
+
+export function metricsAccessMiddleware(req: Request, res: Response, next: NextFunction): void {
+  if (hasValidMetricsToken(req) || isLocalMetricsAccessAllowed(req)) {
+    next();
+    return;
+  }
+
+  res.status(403).json({
+    success: false,
+    message: "Metrics endpoint is not available from this client",
+  });
+}
+
+export async function metricsHandler(_req: Request, res: Response): Promise<void> {
+  res.set("Content-Type", metricsRegistry.contentType);
+  res.end(await metricsRegistry.metrics());
+}

--- a/kalima-platform/backend/src/server.ts
+++ b/kalima-platform/backend/src/server.ts
@@ -19,6 +19,11 @@ import corsOptions from "./config/corsOptions";
 import { registerAllExportResources } from "./apps/store-api/export";
 import { isProtectedSampleStaticPath } from "./libs/sampleStaticAccess";
 import { resolveUploadsRoot } from "./libs/uploadsRoot";
+import {
+  httpMetricsMiddleware,
+  metricsAccessMiddleware,
+  metricsHandler,
+} from "./libs/metrics";
 
 const sentryDsn = process.env.SENTRY_DSN
   || (process.env.NODE_ENV === "production"
@@ -41,6 +46,9 @@ registerAllExportResources();
 app.use(cors(corsOptions));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(httpMetricsMiddleware);
+
+app.get("/metrics", metricsAccessMiddleware, metricsHandler);
 app.use(
   "/uploads/samples",
   (req, res, next) => {

--- a/kalima-platform/docker-compose.prod.yaml
+++ b/kalima-platform/docker-compose.prod.yaml
@@ -25,9 +25,24 @@ services:
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - app-network
+    restart: unless-stopped
+    mem_reservation: 128m
+    mem_limit: 256m
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 8192
+      nproc: 1024
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
 
   backend:
     build:
@@ -59,13 +74,33 @@ services:
       - APP_URL=https://kalima-edu.com
       - SUPPORT_URL=https://kalima-edu.com/support
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - app-network
     volumes:
       - uploads:/app/uploads
       - whatsapp-auth:/app/baileys_auth
+    restart: unless-stopped
+    mem_reservation: 512m
+    mem_limit: 2g
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 16384
+      nproc: 2048
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"require('http').get('http://127.0.0.1:5000/api/v2/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\"",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
 
   postgres:
     # Keep Postgres 17 until the existing data volume is explicitly upgraded.
@@ -80,6 +115,20 @@ services:
       - postgres-data:/var/lib/postgresql/data
     networks:
       - app-network
+    restart: unless-stopped
+    mem_reservation: 1g
+    mem_limit: 3g
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 16384
+      nproc: 2048
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   redis:
     image: redis:8.6.0-alpine
@@ -89,6 +138,20 @@ services:
       - redis-data:/data
     networks:
       - app-network
+    restart: unless-stopped
+    mem_reservation: 128m
+    mem_limit: 512m
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 8192
+      nproc: 1024
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
 networks:
   app-network:

--- a/kalima-platform/docker-compose.prod.yaml
+++ b/kalima-platform/docker-compose.prod.yaml
@@ -34,8 +34,8 @@ services:
     mem_limit: 256m
     ulimits:
       nofile:
-        soft: 4096
-        hard: 8192
+        soft: 65535
+        hard: 65535
       nproc: 1024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/"]
@@ -54,8 +54,9 @@ services:
       - NODE_ENV=production
       - PORT=5000
       - WHATSAPP_AUTH_DIR=/app/baileys_auth
-      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres?schema=kalima
-      - REDIS_URL=redis://redis:6379
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+      - METRICS_TOKEN=${METRICS_TOKEN}
       - ACCESS_TOKEN_SECRET=${ACCESS_TOKEN_SECRET}
       - REFRESH_TOKEN_SECRET=${REFRESH_TOKEN_SECRET}
       - JWT_SECRET=${JWT_SECRET}
@@ -73,13 +74,9 @@ services:
       - INITIAL_ADMIN_NAME=${INITIAL_ADMIN_NAME}
       - APP_URL=https://kalima-edu.com
       - SUPPORT_URL=https://kalima-edu.com/support
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     networks:
       - app-network
+      - data-network
     volumes:
       - uploads:/app/uploads
       - whatsapp-auth:/app/baileys_auth
@@ -88,8 +85,8 @@ services:
     mem_limit: 2g
     ulimits:
       nofile:
-        soft: 8192
-        hard: 16384
+        soft: 65535
+        hard: 65535
       nproc: 2048
     healthcheck:
       test:
@@ -102,63 +99,13 @@ services:
       retries: 3
       start_period: 60s
 
-  postgres:
-    # Keep Postgres 17 until the existing data volume is explicitly upgraded.
-    image: postgres:17-alpine
-    ports:
-      - "5468:5432"
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=postgres
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    networks:
-      - app-network
-    restart: unless-stopped
-    mem_reservation: 1g
-    mem_limit: 3g
-    ulimits:
-      nofile:
-        soft: 8192
-        hard: 16384
-      nproc: 2048
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
-
-  redis:
-    image: redis:8.6.0-alpine
-    ports:
-      - "6770:6379"
-    volumes:
-      - redis-data:/data
-    networks:
-      - app-network
-    restart: unless-stopped
-    mem_reservation: 128m
-    mem_limit: 512m
-    ulimits:
-      nofile:
-        soft: 4096
-        hard: 8192
-      nproc: 1024
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 20s
-
 networks:
   app-network:
     driver: bridge
+  data-network:
+    external: true
+    name: kalima-data-network
 
 volumes:
   uploads:
   whatsapp-auth:
-  postgres-data:
-  redis-data:

--- a/kalima-platform/frontend/e2e/campaign-performance.spec.js
+++ b/kalima-platform/frontend/e2e/campaign-performance.spec.js
@@ -1,0 +1,161 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const outputDir = path.resolve(process.cwd(), "..", "..", "reports", "browser-performance");
+const outputPath = path.join(outputDir, "campaign-visits.json");
+const campaignPaths = (process.env.CAMPAIGN_PERF_PATHS || "/,/market,/e-booklets")
+  .split(",")
+  .map((entry) => entry.trim())
+  .filter(Boolean);
+const unsafePathPattern = /(?:checkout|payment|purchase|cart-purchases|confirm|paymob|stripe|invoice)/i;
+
+function assertSafePath(routePath) {
+  if (unsafePathPattern.test(routePath)) {
+    throw new Error(`Refusing unsafe campaign performance path: ${routePath}`);
+  }
+}
+
+async function installWebVitalsObserver(page) {
+  await page.addInitScript(() => {
+    window.__campaignVitals = {
+      cls: 0,
+      fcp: null,
+      lcp: null,
+      longTasks: [],
+    };
+
+    try {
+      new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          if (entry.name === "first-contentful-paint") {
+            window.__campaignVitals.fcp = entry.startTime;
+          }
+        }
+      }).observe({ type: "paint", buffered: true });
+    } catch {
+      // Browser does not support this performance observer type.
+    }
+
+    try {
+      new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          window.__campaignVitals.lcp = entry.startTime;
+        }
+      }).observe({ type: "largest-contentful-paint", buffered: true });
+    } catch {
+      // Browser does not support this performance observer type.
+    }
+
+    try {
+      new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          if (!entry.hadRecentInput) {
+            window.__campaignVitals.cls += entry.value;
+          }
+        }
+      }).observe({ type: "layout-shift", buffered: true });
+    } catch {
+      // Browser does not support this performance observer type.
+    }
+
+    try {
+      new PerformanceObserver((entryList) => {
+        window.__campaignVitals.longTasks.push(
+          ...entryList.getEntries().map((entry) => ({
+            duration: entry.duration,
+            startTime: entry.startTime,
+          })),
+        );
+      }).observe({ type: "longtask", buffered: true });
+    } catch {
+      // Browser does not support this performance observer type.
+    }
+  });
+}
+
+async function collectVisitMetrics(page, routePath, cacheState) {
+  assertSafePath(routePath);
+  await installWebVitalsObserver(page);
+  const response = await page.goto(routePath, { waitUntil: "networkidle" });
+  await expect(page.locator("body")).toBeVisible();
+  await page.waitForTimeout(500);
+
+  return page.evaluate(({ routePath: evaluatedPath, cacheState: evaluatedCacheState, status }) => {
+    const navigation = performance.getEntriesByType("navigation")[0];
+    const resources = performance.getEntriesByType("resource");
+    const vitals = window.__campaignVitals || {};
+    const transferSize = resources.reduce((total, resource) => total + (resource.transferSize || 0), 0);
+    const encodedBodySize = resources.reduce((total, resource) => total + (resource.encodedBodySize || 0), 0);
+    const decodedBodySize = resources.reduce((total, resource) => total + (resource.decodedBodySize || 0), 0);
+    const resourceTypeCounts = resources.reduce((counts, resource) => {
+      const key = resource.initiatorType || "other";
+      counts[key] = (counts[key] || 0) + 1;
+      return counts;
+    }, {});
+
+    return {
+      path: evaluatedPath,
+      cacheState: evaluatedCacheState,
+      status,
+      collectedAt: new Date().toISOString(),
+      navigation: navigation
+        ? {
+            domContentLoaded: navigation.domContentLoadedEventEnd,
+            load: navigation.loadEventEnd,
+            responseEnd: navigation.responseEnd,
+            transferSize: navigation.transferSize,
+            encodedBodySize: navigation.encodedBodySize,
+            decodedBodySize: navigation.decodedBodySize,
+          }
+        : null,
+      resources: {
+        count: resources.length,
+        transferSize,
+        encodedBodySize,
+        decodedBodySize,
+        byInitiatorType: resourceTypeCounts,
+      },
+      webVitals: {
+        fcp: vitals.fcp ?? null,
+        lcp: vitals.lcp ?? null,
+        cls: vitals.cls ?? null,
+        longTaskCount: Array.isArray(vitals.longTasks) ? vitals.longTasks.length : null,
+        longTaskTotalDuration: Array.isArray(vitals.longTasks)
+          ? vitals.longTasks.reduce((total, task) => total + task.duration, 0)
+          : null,
+      },
+    };
+  }, { routePath, cacheState, status: response?.status() ?? null });
+}
+
+test.describe("campaign browser performance", () => {
+  test("collects uncached and warm visit metrics without payment actions", async ({ browser }) => {
+    const results = [];
+
+    for (const routePath of campaignPaths) {
+      assertSafePath(routePath);
+
+      const coldContext = await browser.newContext();
+      const coldPage = await coldContext.newPage();
+      results.push(await collectVisitMetrics(coldPage, routePath, "uncached"));
+      await coldContext.close();
+
+      const warmContext = await browser.newContext();
+      const warmPage = await warmContext.newPage();
+      await warmPage.goto(routePath, { waitUntil: "networkidle" });
+      results.push(await collectVisitMetrics(warmPage, routePath, "warm"));
+      await warmContext.close();
+    }
+
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify({ campaignPaths, results }, null, 2)}\n`);
+
+    expect(results).toHaveLength(campaignPaths.length * 2);
+    for (const result of results) {
+      expect(result.status, `${result.cacheState} ${result.path}`).toBeLessThan(400);
+      expect(result.navigation, `${result.cacheState} ${result.path} navigation timing`).toBeTruthy();
+    }
+  });
+});

--- a/kalima-platform/frontend/package.json
+++ b/kalima-platform/frontend/package.json
@@ -12,7 +12,8 @@
     "i18n:hardcoded": "node scripts/i18n-hardcoded-audit.mjs",
     "i18n:smoke": "node scripts/i18n-dom-smoke.mjs",
     "i18n:fullstack-smoke": "node scripts/i18n-fullstack-smoke.mjs",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:campaign-performance": "playwright test e2e/campaign-performance.spec.js"
   },
   "eslintIgnore": [
     "src/**/*"

--- a/reports/load-testing/kalima-production-capacity-report-2026-07-27.md
+++ b/reports/load-testing/kalima-production-capacity-report-2026-07-27.md
@@ -8,15 +8,15 @@ Tool: K6 v2.1.0
 
 ## Executive result
 
-Kalima sustained **15 campaign visitor journeys per second** during the complete measured soak with no failed requests, no dropped journeys, no container restart, and no health-check failure.
+Kalima sustained **15 campaign visitor journeys per second for 15 continuous minutes** with no failed requests, no dropped journeys, no container restart, and no health-check failure.
 
 That measured load equals:
 
 - **900 visitor journeys per minute**
 - **54,000 visitor journeys per hour**, if the same arrival rate is maintained
-- **44.18 HTTP requests per second** under the tested visitor mix
-- Approximately **159,000 HTTP requests per hour**
-- Up to **31 simultaneously active K6 users** under this journey timing
+- **44.51 HTTP requests per second** under the tested visitor mix
+- Approximately **160,000 HTTP requests per hour**
+- Up to **30 simultaneously active K6 users** under this journey timing
 
 A short two-minute stage also passed at **20 journeys per second**, equal to 58.06 HTTP requests per second.
 
@@ -68,24 +68,20 @@ Every generated request carried an identifiable load-test user agent and header.
 | Medium | 2 min | 1,201 | 9.83 | 29.05 | 64.07 ms | 164.78 ms | 210.78 ms | 411.42 ms | 0% | 0 | Pass |
 | High | 2 min | 2,401 | 19.62 | 58.06 | 62.28 ms | 149.66 ms | 192.21 ms | 364.68 ms | 0% | 0 | Pass |
 | Failure probe | Aborted after about 16 s | 438 | 27.38 | 93.22 | 62.15 ms | 160.56 ms | 199.31 ms | 273.54 ms before cliff | 6.71% | 35 | Fail |
-| Sustained soak | 8 min | 7,201 | 14.95 | 44.18 | 65.65 ms | 176.79 ms | 264.81 ms | 1,193.66 ms | 0% | 0 | Pass |
-
-An earlier 15-journey soak remained healthy for approximately 9 minutes 28 seconds before the local agent harness terminated its parent command at the harness execution limit.
-
-That partial run had 44 out of 44 successful external health samples, but it did not produce a final K6 summary and is therefore supporting evidence rather than the primary measured result.
+| Sustained soak | 15 min | 13,501 | 14.97 | 44.51 | 62.37 ms | 149.39 ms | 195.36 ms | 590.83 ms | 0% | 0 | Pass |
 
 ## Sustained-soak details
 
-The complete 8-minute soak generated:
+The complete 15-minute soak generated:
 
-- 7,201 visitor journeys
-- 21,280 HTTP requests
-- 224.95 MB received by the K6 generator
+- 13,501 visitor journeys
+- 40,147 HTTP requests
+- 424.18 MB received by the K6 generator
 - 0 failed HTTP requests
 - 0 dropped journeys
 - 100% successful K6 checks
-- 31 maximum simultaneously active K6 users
-- 347 ms p95 complete-journey request time, excluding simulated user think time
+- 30 maximum simultaneously active K6 users
+- 308 ms p95 complete-journey request time, excluding simulated user think time
 
 External production-health monitoring recorded:
 
@@ -149,7 +145,7 @@ Those invalid attempts were excluded and rerun after stabilization.
 
 ### Confirmed sustained capacity
 
-**15 visitor journeys per second for 8 continuous measured minutes**, with separate healthy observation for approximately 9.5 minutes at the same rate.
+**15 visitor journeys per second for 15 continuous measured minutes**.
 
 This corresponds to about 54,000 visitor journeys per hour if traffic and user behavior remain similar.
 
@@ -224,7 +220,7 @@ Real concurrent-user capacity varies with session duration, number of open tabs,
 
 ## Final conclusion
 
-Kalima is healthy and fast at the tested 15-journey sustained level.
+Kalima is healthy and fast at the tested 15-journey sustained level for the full 15-minute proof window.
 
 Latency remained excellent, failures stayed at zero, and application containers retained substantial CPU and memory headroom.
 

--- a/reports/load-testing/kalima-production-capacity-report-2026-07-27.md
+++ b/reports/load-testing/kalima-production-capacity-report-2026-07-27.md
@@ -1,0 +1,235 @@
+# Kalima production load-test report
+
+Date: 2026-07-27 UTC
+
+Target: `https://kalima-edu.com`
+
+Tool: K6 v2.1.0
+
+## Executive result
+
+Kalima sustained **15 campaign visitor journeys per second** during the complete measured soak with no failed requests, no dropped journeys, no container restart, and no health-check failure.
+
+That measured load equals:
+
+- **900 visitor journeys per minute**
+- **54,000 visitor journeys per hour**, if the same arrival rate is maintained
+- **44.18 HTTP requests per second** under the tested visitor mix
+- Approximately **159,000 HTTP requests per hour**
+- Up to **31 simultaneously active K6 users** under this journey timing
+
+A short two-minute stage also passed at **20 journeys per second**, equal to 58.06 HTTP requests per second.
+
+The target stage of 40 journeys per second failed sharply.
+
+K6 achieved 27.38 journeys per second and 93.22 requests per second before timeouts appeared, the host stopped accepting SSH connections, 6.71% of HTTP requests failed, and 35 journeys were dropped.
+
+K6 automatically aborted the stage.
+
+🔹 **Recommended campaign operating limit: 10 new visitor journeys per second, or about 36,000 visitor journeys per hour, until the 40-stage connection cliff is investigated.**
+
+This recommendation keeps roughly 33% headroom below the confirmed 15-journey sustained load and 50% below the short 20-journey passing stage.
+
+## What was tested
+
+The workload modeled anonymous, read-only campaign traffic.
+
+It included:
+
+- Landing-page visits
+- Market-page visits
+- Product-list requests
+- Product-detail requests
+- Level and subject filters
+- E-booklet store visits
+- E-booklet detail requests
+- Sample-directory requests
+- Public contact settings
+- Health checks
+
+The test did not:
+
+- Sign users in
+- Create accounts
+- Modify carts
+- Place orders
+- Trigger payments
+- Send email or WhatsApp messages
+- Write application data
+
+Every generated request carried an identifiable load-test user agent and header.
+
+## Test stages
+
+| Stage | Duration | Completed journeys | Achieved journeys/s | HTTP requests/s | p50 | p95 | p99 | Max | HTTP failures | Dropped journeys | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Baseline | 60 s | 121 | 1.95 | 5.62 | 66.08 ms | 178.87 ms | 238.87 ms | 297.99 ms | 0% | 0 | Pass |
+| Low | 2 min | 600 | 4.92 | 14.54 | 65.67 ms | 168.86 ms | 208.50 ms | 294.17 ms | 0% | 0 | Pass |
+| Medium | 2 min | 1,201 | 9.83 | 29.05 | 64.07 ms | 164.78 ms | 210.78 ms | 411.42 ms | 0% | 0 | Pass |
+| High | 2 min | 2,401 | 19.62 | 58.06 | 62.28 ms | 149.66 ms | 192.21 ms | 364.68 ms | 0% | 0 | Pass |
+| Failure probe | Aborted after about 16 s | 438 | 27.38 | 93.22 | 62.15 ms | 160.56 ms | 199.31 ms | 273.54 ms before cliff | 6.71% | 35 | Fail |
+| Sustained soak | 8 min | 7,201 | 14.95 | 44.18 | 65.65 ms | 176.79 ms | 264.81 ms | 1,193.66 ms | 0% | 0 | Pass |
+
+An earlier 15-journey soak remained healthy for approximately 9 minutes 28 seconds before the local agent harness terminated its parent command at the harness execution limit.
+
+That partial run had 44 out of 44 successful external health samples, but it did not produce a final K6 summary and is therefore supporting evidence rather than the primary measured result.
+
+## Sustained-soak details
+
+The complete 8-minute soak generated:
+
+- 7,201 visitor journeys
+- 21,280 HTTP requests
+- 224.95 MB received by the K6 generator
+- 0 failed HTTP requests
+- 0 dropped journeys
+- 100% successful K6 checks
+- 31 maximum simultaneously active K6 users
+- 347 ms p95 complete-journey request time, excluding simulated user think time
+
+External production-health monitoring recorded:
+
+- 37 health samples
+- 37 HTTP 200 responses
+- 0 availability failures
+- 248 ms p95 public health latency
+- 490 ms maximum public health latency
+
+## Infrastructure observations
+
+Production currently runs one instance of each service on one VPS:
+
+- Nginx frontend
+- Node.js backend
+- PostgreSQL 17
+- Redis 8.6
+
+No container has a CPU or memory limit.
+
+The VPS has approximately 8 GB RAM and 2 GB swap.
+
+Peak resource use during the complete 15-journey soak was:
+
+| Service | Peak CPU | Peak memory |
+| --- | ---: | ---: |
+| Frontend Nginx | 2.92% | 3.93 MiB |
+| Node backend | 45.06% | 265.6 MiB |
+| PostgreSQL | 19.88% | 45.52 MiB |
+| Redis | 0.28% | 12.25 MiB |
+
+The 40-stage failure did not resemble gradual CPU or memory exhaustion.
+
+Immediately before connectivity disappeared, sampled backend CPU was below 1%, PostgreSQL CPU was approximately 1%, and memory was healthy.
+
+The failure was a sharp connection cliff affecting both HTTPS traffic and SSH.
+
+The most likely investigation areas are:
+
+1. VPS or hosting-provider connection-rate protection
+2. Firewall, connection-tracking, or SYN-flood limits
+3. Reverse-proxy or Coolify proxy connection limits
+4. Per-source-IP anti-abuse behavior, because K6 generated traffic from one public IP
+5. File-descriptor or socket backlog limits outside the application containers
+
+The test does not prove which layer caused the cliff.
+
+## Deployment interference handled during testing
+
+Two early stages overlapped with real Coolify deployments.
+
+The first preflight received a 502 and generated no load.
+
+A later 10-journey stage was invalidated because all containers were replaced by a deployment.
+
+Coolify deployment records confirmed these were deployments, not load-induced crashes.
+
+Those invalid attempts were excluded and rerun after stabilization.
+
+## Capacity interpretation
+
+### Confirmed sustained capacity
+
+**15 visitor journeys per second for 8 continuous measured minutes**, with separate healthy observation for approximately 9.5 minutes at the same rate.
+
+This corresponds to about 54,000 visitor journeys per hour if traffic and user behavior remain similar.
+
+### Confirmed short-burst capacity
+
+**20 visitor journeys per second for 2 minutes**, corresponding to about 72,000 journeys per hour if it could be sustained.
+
+It was not soaked long enough to claim 72,000 per hour as sustained capacity.
+
+### Observed failure boundary
+
+The system became unreachable while attempting 40 journeys per second.
+
+The achieved rate before abort was approximately:
+
+- 27.38 journeys per second
+- 93.22 HTTP requests per second
+- 164 active K6 users at the failure point
+
+This is a cliff, not a safe operating point.
+
+### Recommended campaign budget
+
+Use **10 new visitor journeys per second** as the initial production campaign budget.
+
+That equals:
+
+- 600 journeys per minute
+- 36,000 journeys per hour
+- Approximately 29 HTTP requests per second under this mix
+
+Increase beyond that only with live monitoring and after diagnosing the connection cliff.
+
+## Important limitations
+
+This is an HTTP-level K6 test, not a full browser test.
+
+It does not execute React, measure Core Web Vitals, open WebSockets as a browser would, or automatically download every JavaScript, CSS, font, and image asset.
+
+Static assets are configured with one-year immutable caching, so repeat visitors should normally produce less static traffic than first-time uncached browsers.
+
+The test originated from one machine and one public IP.
+
+The 40-stage failure may therefore represent per-source-IP protection rather than aggregate capacity across many geographically distributed visitors.
+
+The workload was anonymous and read-only.
+
+Authenticated dashboards, login, checkout, purchase creation, PDF or e-booklet page rendering, uploads, and WebSocket concurrency require separate controlled tests with dedicated test accounts and test data.
+
+“Users” in this report means generated visitor journeys under the defined timing model.
+
+Real concurrent-user capacity varies with session duration, number of open tabs, browser caching, user actions, geography, and campaign landing-page behavior.
+
+## Recommended actions before a major campaign
+
+1. Put the public frontend and static assets behind a CDN such as Cloudflare.
+2. Inspect host firewall, connection-tracking, SYN backlog, file-descriptor, reverse-proxy, and hosting-provider anti-DDoS limits.
+3. Add CPU and memory limits or reservations so one service cannot starve the entire VPS.
+4. Avoid restarting PostgreSQL and Redis during normal application deployments.
+5. Add Prometheus-compatible infrastructure monitoring for CPU, memory, event-loop lag, PostgreSQL connections, query latency, Redis latency, network packets, connection tracking, and proxy status codes.
+6. Repeat the capacity test from distributed load generators to separate per-IP throttling from true aggregate capacity.
+7. Run a dedicated authenticated test for the exact campaign conversion path.
+8. Run a browser performance test separately for uncached first visits and Core Web Vitals.
+
+## Artifacts
+
+- K6 scenario: `tests/performance/k6/production-capacity.js`
+- Usage guide: `tests/performance/k6/README.md`
+- Raw K6 summaries: `reports/load-testing/raw/`
+- Infrastructure samples: `reports/load-testing/infra/`
+- K6 logs: `reports/load-testing/logs/`
+
+## Final conclusion
+
+Kalima is healthy and fast at the tested 15-journey sustained level.
+
+Latency remained excellent, failures stayed at zero, and application containers retained substantial CPU and memory headroom.
+
+The immediate production risk is not ordinary application saturation.
+
+It is the abrupt network or connection-handling failure observed near 93 requests per second from one source.
+
+Until that cliff is explained, plan campaigns around **10 new visitor journeys per second**, treat **15 per second as confirmed tested capacity**, treat **20 per second as short-burst-only capacity**, and do not target the observed 27-plus journeys-per-second failure region.

--- a/reports/load-testing/raw/soak-015-15m-final.json
+++ b/reports/load-testing/raw/soak-015-15m-final.json
@@ -1,0 +1,539 @@
+{
+  "metrics": {
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 9869543,
+        "rate": 10941.812189640304
+      }
+    },
+    "journey_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 922,
+        "avg": 205.58869713354565,
+        "min": 104,
+        "med": 189,
+        "p(90)": 291,
+        "p(95)": 308,
+        "p(99)": 370
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 424181569,
+        "rate": 470266.46140606
+      }
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "avg": 2.2878190151193936,
+        "min": 0.006,
+        "med": 0.059,
+        "p(90)": 3.051,
+        "p(95)": 3.946699999999998,
+        "p(99)": 54.88854,
+        "max": 160.715
+      },
+      "type": "trend"
+    },
+    "dropped_iterations": {
+      "contains": "default",
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count==0": {
+          "ok": true
+        }
+      },
+      "type": "counter"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 82.46579472937023,
+        "min": 50.356,
+        "med": 62.299,
+        "p(90)": 131.1874,
+        "p(95)": 137.51659999999998,
+        "p(99)": 166.54591999999997,
+        "max": 576.918
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 84.76991852442222,
+        "min": 50.409,
+        "med": 62.369,
+        "p(90)": 135.7168,
+        "p(95)": 149.38939999999997,
+        "p(99)": 195.36166,
+        "max": 590.833
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 40147
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 120438,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "value": 12,
+        "min": 12,
+        "max": 30
+      },
+      "type": "gauge"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 13501,
+        "rate": 14.96780614587056
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.3077608787705182,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 62.457
+      }
+    },
+    "iteration_duration": {
+      "values": {
+        "max": 2847.989584,
+        "avg": 1454.2390413316048,
+        "min": 617.425917,
+        "med": 1457.265125,
+        "p(90)": 2054.294708,
+        "p(95)": 2130.4025,
+        "p(99)": 2229.4755
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "timeout_rate": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 40146
+      },
+      "thresholds": {
+        "rate<0.005": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.01630477993374222,
+        "min": 0.002,
+        "med": 0.016,
+        "p(90)": 0.024,
+        "p(95)": 0.027,
+        "p(99)": 0.036,
+        "max": 0.438
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.36126290881012285,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 70.757
+      }
+    },
+    "server_error_rate": {
+      "contains": "default",
+      "values": {
+        "fails": 40146,
+        "rate": 0,
+        "passes": 0
+      },
+      "thresholds": {
+        "rate<0.02": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 149.38939999999997,
+        "p(99)": 195.36166,
+        "max": 590.833,
+        "avg": 84.76991852442222,
+        "min": 50.409,
+        "med": 62.369,
+        "p(90)": 135.7168
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 80,
+        "min": 80,
+        "max": 80
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.045,
+        "max": 164.537,
+        "avg": 0.7958631030968645,
+        "min": 0,
+        "med": 0.005,
+        "p(90)": 0.01,
+        "p(95)": 0.02
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "rate": 44.508741081272895,
+        "count": 40147
+      },
+      "type": "counter",
+      "contains": "default"
+    }
+  },
+  "setup_data": {
+    "startedAt": "2026-07-27T05:29:41.448Z"
+  },
+  "root_group": {
+    "checks": [
+      {
+        "fails": 0,
+        "name": "landing_html: status 200",
+        "path": "::landing_html: status 200",
+        "id": "76fcc46a1860be2ea12ab580b890a5c3",
+        "passes": 6105
+      },
+      {
+        "name": "landing_html: expected content type",
+        "path": "::landing_html: expected content type",
+        "id": "5f0b000b109a559aa9f7be1752443e40",
+        "passes": 6105,
+        "fails": 0
+      },
+      {
+        "name": "landing_html: non-empty response",
+        "path": "::landing_html: non-empty response",
+        "id": "53e0fd96940b1d3f0b8101fd2c66d3f9",
+        "passes": 6105,
+        "fails": 0
+      },
+      {
+        "passes": 2277,
+        "fails": 0,
+        "name": "ebooklet_html: status 200",
+        "path": "::ebooklet_html: status 200",
+        "id": "cbba479753b795ead0c7ee83a2d62296"
+      },
+      {
+        "name": "ebooklet_html: expected content type",
+        "path": "::ebooklet_html: expected content type",
+        "id": "b0ca7ce72227f85363b644263dd32d2e",
+        "passes": 2277,
+        "fails": 0
+      },
+      {
+        "name": "ebooklet_html: non-empty response",
+        "path": "::ebooklet_html: non-empty response",
+        "id": "4f5f07ddc84fa767ce771b027a452daf",
+        "passes": 2277,
+        "fails": 0
+      },
+      {
+        "name": "products_list: status 200",
+        "path": "::products_list: status 200",
+        "id": "36ba3e2129d77e15d1ca1f7ec889f3f0",
+        "passes": 10254,
+        "fails": 0
+      },
+      {
+        "name": "products_list: expected content type",
+        "path": "::products_list: expected content type",
+        "id": "dfb8c2dc0b626ed47282eb649a92fe12",
+        "passes": 10254,
+        "fails": 0
+      },
+      {
+        "path": "::products_list: non-empty response",
+        "id": "294c5cc6542b98db51b619f63a5a401a",
+        "passes": 10254,
+        "fails": 0,
+        "name": "products_list: non-empty response"
+      },
+      {
+        "name": "ebooklet_store: status 200",
+        "path": "::ebooklet_store: status 200",
+        "id": "832063d4949942e1d469241a566b5ada",
+        "passes": 2277,
+        "fails": 0
+      },
+      {
+        "name": "ebooklet_store: expected content type",
+        "path": "::ebooklet_store: expected content type",
+        "id": "4bc45407897cacfac72cde03cb436cfc",
+        "passes": 2277,
+        "fails": 0
+      },
+      {
+        "id": "ba8131c52dc20ff2e672eb2ebdaf2264",
+        "passes": 2277,
+        "fails": 0,
+        "name": "ebooklet_store: non-empty response",
+        "path": "::ebooklet_store: non-empty response"
+      },
+      {
+        "id": "47ce57d3148632e68074326856b023a1",
+        "passes": 4149,
+        "fails": 0,
+        "name": "market_html: status 200",
+        "path": "::market_html: status 200"
+      },
+      {
+        "name": "market_html: expected content type",
+        "path": "::market_html: expected content type",
+        "id": "936bf9e276efc5c9c1e46e08c3955ae1",
+        "passes": 4149,
+        "fails": 0
+      },
+      {
+        "path": "::market_html: non-empty response",
+        "id": "dc009ed78805d5aa7e2eb4459e76aa1a",
+        "passes": 4149,
+        "fails": 0,
+        "name": "market_html: non-empty response"
+      },
+      {
+        "fails": 0,
+        "name": "product_detail: status 200",
+        "path": "::product_detail: status 200",
+        "id": "5261ab7983594e05def270714e50c43c",
+        "passes": 2758
+      },
+      {
+        "fails": 0,
+        "name": "product_detail: expected content type",
+        "path": "::product_detail: expected content type",
+        "id": "3218a9dd21e9dc36f2bd3cd25317d498",
+        "passes": 2758
+      },
+      {
+        "name": "product_detail: non-empty response",
+        "path": "::product_detail: non-empty response",
+        "id": "3d67d717356cbb8369f4dd3ab14337e8",
+        "passes": 2758,
+        "fails": 0
+      },
+      {
+        "id": "fa401ddfc5f36f99af49757a3ae7a41f",
+        "passes": 4149,
+        "fails": 0,
+        "name": "levels_list: status 200",
+        "path": "::levels_list: status 200"
+      },
+      {
+        "name": "levels_list: expected content type",
+        "path": "::levels_list: expected content type",
+        "id": "d52d104072ffefa55b2ca4dba4701991",
+        "passes": 4149,
+        "fails": 0
+      },
+      {
+        "fails": 0,
+        "name": "levels_list: non-empty response",
+        "path": "::levels_list: non-empty response",
+        "id": "a1b6545baaa93d1d2ef25e782b434d37",
+        "passes": 4149
+      },
+      {
+        "name": "subjects_list: status 200",
+        "path": "::subjects_list: status 200",
+        "id": "ebf2a5e67dff3340f094029a97f82d70",
+        "passes": 4149,
+        "fails": 0
+      },
+      {
+        "path": "::subjects_list: expected content type",
+        "id": "1f9264b29ca332aaad8777fb362512d8",
+        "passes": 4149,
+        "fails": 0,
+        "name": "subjects_list: expected content type"
+      },
+      {
+        "path": "::subjects_list: non-empty response",
+        "id": "0acc2a36202f32bcbbe3f305657cad1c",
+        "passes": 4149,
+        "fails": 0,
+        "name": "subjects_list: non-empty response"
+      },
+      {
+        "path": "::sample_sections: status 200",
+        "id": "f37d3e1fbdc463d3901b957fa5d16256",
+        "passes": 970,
+        "fails": 0,
+        "name": "sample_sections: status 200"
+      },
+      {
+        "name": "sample_sections: expected content type",
+        "path": "::sample_sections: expected content type",
+        "id": "e8bfd786c87b069aba1d85a9a002f882",
+        "passes": 970,
+        "fails": 0
+      },
+      {
+        "name": "sample_sections: non-empty response",
+        "path": "::sample_sections: non-empty response",
+        "id": "e4c725b88c6752a4fa97e8e7d9694c08",
+        "passes": 970,
+        "fails": 0
+      },
+      {
+        "name": "contact_settings: status 200",
+        "path": "::contact_settings: status 200",
+        "id": "ab8469c418cc77ecf7dae6d31b4ebd49",
+        "passes": 970,
+        "fails": 0
+      },
+      {
+        "name": "contact_settings: expected content type",
+        "path": "::contact_settings: expected content type",
+        "id": "5fc3e4747d868ed95ab339edc01d1d6c",
+        "passes": 970,
+        "fails": 0
+      },
+      {
+        "name": "contact_settings: non-empty response",
+        "path": "::contact_settings: non-empty response",
+        "id": "2502a0d78d6164ea3bcd86df3b15c0ec",
+        "passes": 970,
+        "fails": 0
+      },
+      {
+        "passes": 970,
+        "fails": 0,
+        "name": "health: status 200",
+        "path": "::health: status 200",
+        "id": "73274babb93df6aaf60956333620494b"
+      },
+      {
+        "passes": 970,
+        "fails": 0,
+        "name": "health: expected content type",
+        "path": "::health: expected content type",
+        "id": "ab62d5933af63d9bbc37dd5d2201fa87"
+      },
+      {
+        "name": "health: non-empty response",
+        "path": "::health: non-empty response",
+        "id": "74df10260207d786119a58cee19a90a2",
+        "passes": 970,
+        "fails": 0
+      },
+      {
+        "passes": 1118,
+        "fails": 0,
+        "name": "ebooklet_detail: status 200",
+        "path": "::ebooklet_detail: status 200",
+        "id": "6ac2c3d577fd01a668511ac883d2e8d1"
+      },
+      {
+        "name": "ebooklet_detail: expected content type",
+        "path": "::ebooklet_detail: expected content type",
+        "id": "d1bfde1b8fc99c2f24a48267bdc0cc43",
+        "passes": 1118,
+        "fails": 0
+      },
+      {
+        "name": "ebooklet_detail: non-empty response",
+        "path": "::ebooklet_detail: non-empty response",
+        "id": "e1de9012ed0cadddc1856afba3f02d95",
+        "passes": 1118,
+        "fails": 0
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": ""
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 902002.596
+  }
+}

--- a/reports/load-testing/raw/soak-015-8m.json
+++ b/reports/load-testing/raw/soak-015-8m.json
@@ -1,0 +1,539 @@
+{
+  "setup_data": {
+    "startedAt": "2026-07-27T05:19:12.129Z"
+  },
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 3228,
+          "fails": 0,
+          "name": "landing_html: status 200",
+          "path": "::landing_html: status 200",
+          "id": "76fcc46a1860be2ea12ab580b890a5c3"
+        },
+        {
+          "path": "::landing_html: expected content type",
+          "id": "5f0b000b109a559aa9f7be1752443e40",
+          "passes": 3228,
+          "fails": 0,
+          "name": "landing_html: expected content type"
+        },
+        {
+          "path": "::landing_html: non-empty response",
+          "id": "53e0fd96940b1d3f0b8101fd2c66d3f9",
+          "passes": 3228,
+          "fails": 0,
+          "name": "landing_html: non-empty response"
+        },
+        {
+          "name": "ebooklet_html: status 200",
+          "path": "::ebooklet_html: status 200",
+          "id": "cbba479753b795ead0c7ee83a2d62296",
+          "passes": 1253,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_html: expected content type",
+          "path": "::ebooklet_html: expected content type",
+          "id": "b0ca7ce72227f85363b644263dd32d2e",
+          "passes": 1253,
+          "fails": 0
+        },
+        {
+          "passes": 1253,
+          "fails": 0,
+          "name": "ebooklet_html: non-empty response",
+          "path": "::ebooklet_html: non-empty response",
+          "id": "4f5f07ddc84fa767ce771b027a452daf"
+        },
+        {
+          "name": "ebooklet_store: status 200",
+          "path": "::ebooklet_store: status 200",
+          "id": "832063d4949942e1d469241a566b5ada",
+          "passes": 1253,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "ebooklet_store: expected content type",
+          "path": "::ebooklet_store: expected content type",
+          "id": "4bc45407897cacfac72cde03cb436cfc",
+          "passes": 1253
+        },
+        {
+          "name": "ebooklet_store: non-empty response",
+          "path": "::ebooklet_store: non-empty response",
+          "id": "ba8131c52dc20ff2e672eb2ebdaf2264",
+          "passes": 1253,
+          "fails": 0
+        },
+        {
+          "name": "products_list: status 200",
+          "path": "::products_list: status 200",
+          "id": "36ba3e2129d77e15d1ca1f7ec889f3f0",
+          "passes": 5374,
+          "fails": 0
+        },
+        {
+          "passes": 5374,
+          "fails": 0,
+          "name": "products_list: expected content type",
+          "path": "::products_list: expected content type",
+          "id": "dfb8c2dc0b626ed47282eb649a92fe12"
+        },
+        {
+          "path": "::products_list: non-empty response",
+          "id": "294c5cc6542b98db51b619f63a5a401a",
+          "passes": 5374,
+          "fails": 0,
+          "name": "products_list: non-empty response"
+        },
+        {
+          "name": "product_detail: status 200",
+          "path": "::product_detail: status 200",
+          "id": "5261ab7983594e05def270714e50c43c",
+          "passes": 1411,
+          "fails": 0
+        },
+        {
+          "name": "product_detail: expected content type",
+          "path": "::product_detail: expected content type",
+          "id": "3218a9dd21e9dc36f2bd3cd25317d498",
+          "passes": 1411,
+          "fails": 0
+        },
+        {
+          "name": "product_detail: non-empty response",
+          "path": "::product_detail: non-empty response",
+          "id": "3d67d717356cbb8369f4dd3ab14337e8",
+          "passes": 1411,
+          "fails": 0
+        },
+        {
+          "name": "market_html: status 200",
+          "path": "::market_html: status 200",
+          "id": "47ce57d3148632e68074326856b023a1",
+          "passes": 2146,
+          "fails": 0
+        },
+        {
+          "name": "market_html: expected content type",
+          "path": "::market_html: expected content type",
+          "id": "936bf9e276efc5c9c1e46e08c3955ae1",
+          "passes": 2146,
+          "fails": 0
+        },
+        {
+          "id": "dc009ed78805d5aa7e2eb4459e76aa1a",
+          "passes": 2146,
+          "fails": 0,
+          "name": "market_html: non-empty response",
+          "path": "::market_html: non-empty response"
+        },
+        {
+          "passes": 2146,
+          "fails": 0,
+          "name": "levels_list: status 200",
+          "path": "::levels_list: status 200",
+          "id": "fa401ddfc5f36f99af49757a3ae7a41f"
+        },
+        {
+          "id": "d52d104072ffefa55b2ca4dba4701991",
+          "passes": 2146,
+          "fails": 0,
+          "name": "levels_list: expected content type",
+          "path": "::levels_list: expected content type"
+        },
+        {
+          "fails": 0,
+          "name": "levels_list: non-empty response",
+          "path": "::levels_list: non-empty response",
+          "id": "a1b6545baaa93d1d2ef25e782b434d37",
+          "passes": 2146
+        },
+        {
+          "name": "subjects_list: status 200",
+          "path": "::subjects_list: status 200",
+          "id": "ebf2a5e67dff3340f094029a97f82d70",
+          "passes": 2146,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "subjects_list: expected content type",
+          "path": "::subjects_list: expected content type",
+          "id": "1f9264b29ca332aaad8777fb362512d8",
+          "passes": 2146
+        },
+        {
+          "path": "::subjects_list: non-empty response",
+          "id": "0acc2a36202f32bcbbe3f305657cad1c",
+          "passes": 2146,
+          "fails": 0,
+          "name": "subjects_list: non-empty response"
+        },
+        {
+          "passes": 600,
+          "fails": 0,
+          "name": "ebooklet_detail: status 200",
+          "path": "::ebooklet_detail: status 200",
+          "id": "6ac2c3d577fd01a668511ac883d2e8d1"
+        },
+        {
+          "name": "ebooklet_detail: expected content type",
+          "path": "::ebooklet_detail: expected content type",
+          "id": "d1bfde1b8fc99c2f24a48267bdc0cc43",
+          "passes": 600,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_detail: non-empty response",
+          "path": "::ebooklet_detail: non-empty response",
+          "id": "e1de9012ed0cadddc1856afba3f02d95",
+          "passes": 600,
+          "fails": 0
+        },
+        {
+          "path": "::sample_sections: status 200",
+          "id": "f37d3e1fbdc463d3901b957fa5d16256",
+          "passes": 574,
+          "fails": 0,
+          "name": "sample_sections: status 200"
+        },
+        {
+          "id": "e8bfd786c87b069aba1d85a9a002f882",
+          "passes": 574,
+          "fails": 0,
+          "name": "sample_sections: expected content type",
+          "path": "::sample_sections: expected content type"
+        },
+        {
+          "path": "::sample_sections: non-empty response",
+          "id": "e4c725b88c6752a4fa97e8e7d9694c08",
+          "passes": 574,
+          "fails": 0,
+          "name": "sample_sections: non-empty response"
+        },
+        {
+          "name": "contact_settings: status 200",
+          "path": "::contact_settings: status 200",
+          "id": "ab8469c418cc77ecf7dae6d31b4ebd49",
+          "passes": 574,
+          "fails": 0
+        },
+        {
+          "name": "contact_settings: expected content type",
+          "path": "::contact_settings: expected content type",
+          "id": "5fc3e4747d868ed95ab339edc01d1d6c",
+          "passes": 574,
+          "fails": 0
+        },
+        {
+          "name": "contact_settings: non-empty response",
+          "path": "::contact_settings: non-empty response",
+          "id": "2502a0d78d6164ea3bcd86df3b15c0ec",
+          "passes": 574,
+          "fails": 0
+        },
+        {
+          "name": "health: status 200",
+          "path": "::health: status 200",
+          "id": "73274babb93df6aaf60956333620494b",
+          "passes": 574,
+          "fails": 0
+        },
+        {
+          "path": "::health: expected content type",
+          "id": "ab62d5933af63d9bbc37dd5d2201fa87",
+          "passes": 574,
+          "fails": 0,
+          "name": "health: expected content type"
+        },
+        {
+          "path": "::health: non-empty response",
+          "id": "74df10260207d786119a58cee19a90a2",
+          "passes": 574,
+          "fails": 0,
+          "name": "health: non-empty response"
+        }
+      ],
+    "name": "",
+    "path": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 481657.273,
+    "isStdOutTTY": false,
+    "isStdErrTTY": false
+  },
+  "metrics": {
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 80,
+        "min": 80,
+        "max": 80
+      },
+      "type": "gauge"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1.465714708647011,
+        "min": 0,
+        "med": 0.006,
+        "p(90)": 0.019,
+        "p(95)": 0.029,
+        "p(99)": 94.08147999999915,
+        "max": 326.95
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 12,
+        "min": 12,
+        "max": 31
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 85.137,
+        "avg": 0.4844800281954889,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 5400416,
+        "rate": 11212.15499635983
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 242.379,
+        "avg": 0.5720966635338345
+      }
+    },
+    "http_req_sending": {
+      "values": {
+        "p(90)": 0.032,
+        "p(95)": 0.037,
+        "p(99)": 0.057,
+        "max": 2.111,
+        "avg": 0.018416776315788214,
+        "min": 0.002,
+        "med": 0.016
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 615.69125,
+        "med": 1463.159166,
+        "p(90)": 2066.028084,
+        "p(95)": 2145.627208,
+        "p(99)": 2270.049542,
+        "max": 2918.640625,
+        "avg": 1465.1286316967064
+      }
+    },
+    "server_error_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 21279,
+        "rate": 0
+      },
+      "thresholds": {
+        "rate<0.02": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 63837,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "values": {
+        "med": 65.652,
+        "p(90)": 143.35559999999998,
+        "p(95)": 176.7854499999999,
+        "p(99)": 264.8091899999999,
+        "max": 1193.662,
+        "avg": 90.5998727913527,
+        "min": 50.499
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "journey_duration": {
+      "values": {
+        "p(99)": 564,
+        "max": 1530,
+        "avg": 219.1033189834745,
+        "min": 105,
+        "med": 192,
+        "p(90)": 306,
+        "p(95)": 347
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 7201,
+        "rate": 14.950464580652143
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 21280,
+        "rate": 44.18079242831241
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 149.7926,
+        "p(99)": 253.89310999999992,
+        "max": 1000.544,
+        "avg": 88.0756220864663,
+        "min": 50.433,
+        "med": 65.5685,
+        "p(90)": 136.1246
+      }
+    },
+    "dropped_iterations": {
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "count": 0
+      },
+      "thresholds": {
+        "count==0": {
+          "ok": true
+        }
+      },
+      "type": "counter"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 3.950049999999999,
+        "p(99)": 55.04021,
+        "max": 533.567,
+        "avg": 2.505833928571389,
+        "min": 0.007,
+        "med": 0.081,
+        "p(90)": 2.987
+      }
+    },
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 21280,
+        "rate": 0
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 143.35559999999998,
+        "p(95)": 176.7854499999999,
+        "p(99)": 264.8091899999999,
+        "max": 1193.662,
+        "avg": 90.5998727913527,
+        "min": 50.499,
+        "med": 65.652
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      }
+    },
+    "timeout_rate": {
+      "thresholds": {
+        "rate<0.005": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 21279,
+        "rate": 0
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 224945520,
+        "rate": 467024.02851498104
+      }
+    }
+  }
+}

--- a/reports/load-testing/raw/stage-002.json
+++ b/reports/load-testing/raw/stage-002.json
@@ -1,0 +1,539 @@
+{
+  "root_group": {
+    "checks": [
+      {
+        "fails": 0,
+        "name": "landing_html: status 200",
+        "path": "::landing_html: status 200",
+        "id": "76fcc46a1860be2ea12ab580b890a5c3",
+        "passes": 60
+      },
+      {
+        "passes": 60,
+        "fails": 0,
+        "name": "landing_html: expected content type",
+        "path": "::landing_html: expected content type",
+        "id": "5f0b000b109a559aa9f7be1752443e40"
+      },
+      {
+        "name": "landing_html: non-empty response",
+        "path": "::landing_html: non-empty response",
+        "id": "53e0fd96940b1d3f0b8101fd2c66d3f9",
+        "passes": 60,
+        "fails": 0
+      },
+      {
+        "passes": 96,
+        "fails": 0,
+        "name": "products_list: status 200",
+        "path": "::products_list: status 200",
+        "id": "36ba3e2129d77e15d1ca1f7ec889f3f0"
+      },
+      {
+        "fails": 0,
+        "name": "products_list: expected content type",
+        "path": "::products_list: expected content type",
+        "id": "dfb8c2dc0b626ed47282eb649a92fe12",
+        "passes": 96
+      },
+      {
+        "passes": 96,
+        "fails": 0,
+        "name": "products_list: non-empty response",
+        "path": "::products_list: non-empty response",
+        "id": "294c5cc6542b98db51b619f63a5a401a"
+      },
+      {
+        "name": "ebooklet_html: status 200",
+        "path": "::ebooklet_html: status 200",
+        "id": "cbba479753b795ead0c7ee83a2d62296",
+        "passes": 18,
+        "fails": 0
+      },
+      {
+        "name": "ebooklet_html: expected content type",
+        "path": "::ebooklet_html: expected content type",
+        "id": "b0ca7ce72227f85363b644263dd32d2e",
+        "passes": 18,
+        "fails": 0
+      },
+      {
+        "passes": 18,
+        "fails": 0,
+        "name": "ebooklet_html: non-empty response",
+        "path": "::ebooklet_html: non-empty response",
+        "id": "4f5f07ddc84fa767ce771b027a452daf"
+      },
+      {
+        "name": "ebooklet_store: status 200",
+        "path": "::ebooklet_store: status 200",
+        "id": "832063d4949942e1d469241a566b5ada",
+        "passes": 18,
+        "fails": 0
+      },
+      {
+        "passes": 18,
+        "fails": 0,
+        "name": "ebooklet_store: expected content type",
+        "path": "::ebooklet_store: expected content type",
+        "id": "4bc45407897cacfac72cde03cb436cfc"
+      },
+      {
+        "path": "::ebooklet_store: non-empty response",
+        "id": "ba8131c52dc20ff2e672eb2ebdaf2264",
+        "passes": 18,
+        "fails": 0,
+        "name": "ebooklet_store: non-empty response"
+      },
+      {
+        "name": "ebooklet_detail: status 200",
+        "path": "::ebooklet_detail: status 200",
+        "id": "6ac2c3d577fd01a668511ac883d2e8d1",
+        "passes": 8,
+        "fails": 0
+      },
+      {
+        "id": "d1bfde1b8fc99c2f24a48267bdc0cc43",
+        "passes": 8,
+        "fails": 0,
+        "name": "ebooklet_detail: expected content type",
+        "path": "::ebooklet_detail: expected content type"
+      },
+      {
+        "id": "e1de9012ed0cadddc1856afba3f02d95",
+        "passes": 8,
+        "fails": 0,
+        "name": "ebooklet_detail: non-empty response",
+        "path": "::ebooklet_detail: non-empty response"
+      },
+      {
+        "passes": 7,
+        "fails": 0,
+        "name": "sample_sections: status 200",
+        "path": "::sample_sections: status 200",
+        "id": "f37d3e1fbdc463d3901b957fa5d16256"
+      },
+      {
+        "fails": 0,
+        "name": "sample_sections: expected content type",
+        "path": "::sample_sections: expected content type",
+        "id": "e8bfd786c87b069aba1d85a9a002f882",
+        "passes": 7
+      },
+      {
+        "name": "sample_sections: non-empty response",
+        "path": "::sample_sections: non-empty response",
+        "id": "e4c725b88c6752a4fa97e8e7d9694c08",
+        "passes": 7,
+        "fails": 0
+      },
+      {
+        "name": "contact_settings: status 200",
+        "path": "::contact_settings: status 200",
+        "id": "ab8469c418cc77ecf7dae6d31b4ebd49",
+        "passes": 7,
+        "fails": 0
+      },
+      {
+        "passes": 7,
+        "fails": 0,
+        "name": "contact_settings: expected content type",
+        "path": "::contact_settings: expected content type",
+        "id": "5fc3e4747d868ed95ab339edc01d1d6c"
+      },
+      {
+        "passes": 7,
+        "fails": 0,
+        "name": "contact_settings: non-empty response",
+        "path": "::contact_settings: non-empty response",
+        "id": "2502a0d78d6164ea3bcd86df3b15c0ec"
+      },
+      {
+        "passes": 7,
+        "fails": 0,
+        "name": "health: status 200",
+        "path": "::health: status 200",
+        "id": "73274babb93df6aaf60956333620494b"
+      },
+      {
+        "name": "health: expected content type",
+        "path": "::health: expected content type",
+        "id": "ab62d5933af63d9bbc37dd5d2201fa87",
+        "passes": 7,
+        "fails": 0
+      },
+      {
+        "id": "74df10260207d786119a58cee19a90a2",
+        "passes": 7,
+        "fails": 0,
+        "name": "health: non-empty response",
+        "path": "::health: non-empty response"
+      },
+      {
+        "name": "product_detail: status 200",
+        "path": "::product_detail: status 200",
+        "id": "5261ab7983594e05def270714e50c43c",
+        "passes": 19,
+        "fails": 0
+      },
+      {
+        "passes": 19,
+        "fails": 0,
+        "name": "product_detail: expected content type",
+        "path": "::product_detail: expected content type",
+        "id": "3218a9dd21e9dc36f2bd3cd25317d498"
+      },
+      {
+        "name": "product_detail: non-empty response",
+        "path": "::product_detail: non-empty response",
+        "id": "3d67d717356cbb8369f4dd3ab14337e8",
+        "passes": 19,
+        "fails": 0
+      },
+      {
+        "name": "market_html: status 200",
+        "path": "::market_html: status 200",
+        "id": "47ce57d3148632e68074326856b023a1",
+        "passes": 36,
+        "fails": 0
+      },
+      {
+        "path": "::market_html: expected content type",
+        "id": "936bf9e276efc5c9c1e46e08c3955ae1",
+        "passes": 36,
+        "fails": 0,
+        "name": "market_html: expected content type"
+      },
+      {
+        "name": "market_html: non-empty response",
+        "path": "::market_html: non-empty response",
+        "id": "dc009ed78805d5aa7e2eb4459e76aa1a",
+        "passes": 36,
+        "fails": 0
+      },
+      {
+        "passes": 36,
+        "fails": 0,
+        "name": "levels_list: status 200",
+        "path": "::levels_list: status 200",
+        "id": "fa401ddfc5f36f99af49757a3ae7a41f"
+      },
+      {
+        "name": "levels_list: expected content type",
+        "path": "::levels_list: expected content type",
+        "id": "d52d104072ffefa55b2ca4dba4701991",
+        "passes": 36,
+        "fails": 0
+      },
+      {
+        "path": "::levels_list: non-empty response",
+        "id": "a1b6545baaa93d1d2ef25e782b434d37",
+        "passes": 36,
+        "fails": 0,
+        "name": "levels_list: non-empty response"
+      },
+      {
+        "name": "subjects_list: status 200",
+        "path": "::subjects_list: status 200",
+        "id": "ebf2a5e67dff3340f094029a97f82d70",
+        "passes": 36,
+        "fails": 0
+      },
+      {
+        "name": "subjects_list: expected content type",
+        "path": "::subjects_list: expected content type",
+        "id": "1f9264b29ca332aaad8777fb362512d8",
+        "passes": 36,
+        "fails": 0
+      },
+      {
+        "name": "subjects_list: non-empty response",
+        "path": "::subjects_list: non-empty response",
+        "id": "0acc2a36202f32bcbbe3f305657cad1c",
+        "passes": 36,
+        "fails": 0
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 62045.751,
+    "isStdOutTTY": false,
+    "isStdErrTTY": false
+  },
+  "metrics": {
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1537.2595395950407,
+        "min": 728.615625,
+        "med": 1577.801958,
+        "p(90)": 2089.14475,
+        "p(95)": 2191.4675,
+        "p(99)": 2264.9864918,
+        "max": 2334.014875
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 1.9501738322097188,
+        "count": 121
+      }
+    },
+    "dropped_iterations": {
+      "values": {
+        "rate": 0,
+        "count": 0
+      },
+      "thresholds": {
+        "count==0": {
+          "ok": true
+        }
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 160.4506,
+        "p(95)": 178.86939999999998,
+        "p(99)": 238.87011999999987,
+        "max": 297.994,
+        "avg": 93.29770200573068,
+        "min": 51.217,
+        "med": 66.08
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 1044,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "server_error_rate": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 348
+      },
+      "thresholds": {
+        "rate<0.02": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "timeout_rate": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 348
+      },
+      "thresholds": {
+        "rate<0.005": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 7.509979942693407,
+        "min": 0,
+        "med": 0,
+        "p(90)": 59.4338,
+        "p(95)": 62.187999999999995,
+        "p(99)": 72.42792,
+        "max": 94.577
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 159314,
+        "rate": 2567.685900038505
+      }
+    },
+    "vus": {
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 4
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "http_req_duration{expected_response:true}": {
+      "values": {
+        "p(90)": 160.4506,
+        "p(95)": 178.86939999999998,
+        "p(99)": 238.87011999999987,
+        "max": 297.994,
+        "avg": 93.29770200573068,
+        "min": 51.217,
+        "med": 66.08
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 15.671375358166193,
+        "min": 0.002,
+        "med": 0.007,
+        "p(90)": 112.0454,
+        "p(95)": 116.45219999999999,
+        "p(99)": 128.89351999999997,
+        "max": 147.407
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 16,
+        "min": 16,
+        "max": 16
+      }
+    },
+    "http_req_sending": {
+      "values": {
+        "p(99)": 0.07604,
+        "max": 0.31,
+        "avg": 0.025618911174785052,
+        "min": 0.005,
+        "med": 0.021,
+        "p(90)": 0.041,
+        "p(95)": 0.057599999999999985
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 217.69863999999998,
+        "max": 258.867,
+        "avg": 90.88609742120343,
+        "min": 51.043,
+        "med": 65.968,
+        "p(90)": 153.6388,
+        "p(95)": 167.5744
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "p(95)": 52.9704,
+        "p(99)": 54.6336,
+        "max": 62.195,
+        "avg": 6.261378223495701,
+        "min": 0,
+        "med": 0,
+        "p(90)": 51.395199999999996
+      },
+      "type": "trend"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 3.2304000000000004,
+        "p(95)": 4.0703999999999985,
+        "p(99)": 54.526759999999996,
+        "max": 57.956,
+        "avg": 2.3859856733524363,
+        "min": 0.019,
+        "med": 0.117
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 349,
+        "rate": 5.624881549100759
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 3957504,
+        "rate": 63783.64249310158
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 349
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "journey_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 339,
+        "p(95)": 357,
+        "p(99)": 449.2,
+        "max": 587,
+        "avg": 243.3801652892562,
+        "min": 108,
+        "med": 225
+      }
+    }
+  },
+  "setup_data": {
+    "startedAt": "2026-07-27T04:56:24.197Z"
+  }
+}

--- a/reports/load-testing/raw/stage-005.json
+++ b/reports/load-testing/raw/stage-005.json
@@ -1,0 +1,539 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "landing_html: status 200",
+          "path": "::landing_html: status 200",
+          "id": "76fcc46a1860be2ea12ab580b890a5c3",
+          "passes": 269,
+          "fails": 0
+        },
+        {
+          "name": "landing_html: expected content type",
+          "path": "::landing_html: expected content type",
+          "id": "5f0b000b109a559aa9f7be1752443e40",
+          "passes": 269,
+          "fails": 0
+        },
+        {
+          "name": "landing_html: non-empty response",
+          "path": "::landing_html: non-empty response",
+          "id": "53e0fd96940b1d3f0b8101fd2c66d3f9",
+          "passes": 269,
+          "fails": 0
+        },
+        {
+          "name": "products_list: status 200",
+          "path": "::products_list: status 200",
+          "id": "36ba3e2129d77e15d1ca1f7ec889f3f0",
+          "passes": 454,
+          "fails": 0
+        },
+        {
+          "name": "products_list: expected content type",
+          "path": "::products_list: expected content type",
+          "id": "dfb8c2dc0b626ed47282eb649a92fe12",
+          "passes": 454,
+          "fails": 0
+        },
+        {
+          "path": "::products_list: non-empty response",
+          "id": "294c5cc6542b98db51b619f63a5a401a",
+          "passes": 454,
+          "fails": 0,
+          "name": "products_list: non-empty response"
+        },
+        {
+          "passes": 111,
+          "fails": 0,
+          "name": "product_detail: status 200",
+          "path": "::product_detail: status 200",
+          "id": "5261ab7983594e05def270714e50c43c"
+        },
+        {
+          "id": "3218a9dd21e9dc36f2bd3cd25317d498",
+          "passes": 111,
+          "fails": 0,
+          "name": "product_detail: expected content type",
+          "path": "::product_detail: expected content type"
+        },
+        {
+          "id": "3d67d717356cbb8369f4dd3ab14337e8",
+          "passes": 111,
+          "fails": 0,
+          "name": "product_detail: non-empty response",
+          "path": "::product_detail: non-empty response"
+        },
+        {
+          "name": "market_html: status 200",
+          "path": "::market_html: status 200",
+          "id": "47ce57d3148632e68074326856b023a1",
+          "passes": 185,
+          "fails": 0
+        },
+        {
+          "name": "market_html: expected content type",
+          "path": "::market_html: expected content type",
+          "id": "936bf9e276efc5c9c1e46e08c3955ae1",
+          "passes": 185,
+          "fails": 0
+        },
+        {
+          "path": "::market_html: non-empty response",
+          "id": "dc009ed78805d5aa7e2eb4459e76aa1a",
+          "passes": 185,
+          "fails": 0,
+          "name": "market_html: non-empty response"
+        },
+        {
+          "name": "levels_list: status 200",
+          "path": "::levels_list: status 200",
+          "id": "fa401ddfc5f36f99af49757a3ae7a41f",
+          "passes": 185,
+          "fails": 0
+        },
+        {
+          "path": "::levels_list: expected content type",
+          "id": "d52d104072ffefa55b2ca4dba4701991",
+          "passes": 185,
+          "fails": 0,
+          "name": "levels_list: expected content type"
+        },
+        {
+          "id": "a1b6545baaa93d1d2ef25e782b434d37",
+          "passes": 185,
+          "fails": 0,
+          "name": "levels_list: non-empty response",
+          "path": "::levels_list: non-empty response"
+        },
+        {
+          "fails": 0,
+          "name": "subjects_list: status 200",
+          "path": "::subjects_list: status 200",
+          "id": "ebf2a5e67dff3340f094029a97f82d70",
+          "passes": 185
+        },
+        {
+          "fails": 0,
+          "name": "subjects_list: expected content type",
+          "path": "::subjects_list: expected content type",
+          "id": "1f9264b29ca332aaad8777fb362512d8",
+          "passes": 185
+        },
+        {
+          "name": "subjects_list: non-empty response",
+          "path": "::subjects_list: non-empty response",
+          "id": "0acc2a36202f32bcbbe3f305657cad1c",
+          "passes": 185,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_html: status 200",
+          "path": "::ebooklet_html: status 200",
+          "id": "cbba479753b795ead0c7ee83a2d62296",
+          "passes": 109,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_html: expected content type",
+          "path": "::ebooklet_html: expected content type",
+          "id": "b0ca7ce72227f85363b644263dd32d2e",
+          "passes": 109,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "ebooklet_html: non-empty response",
+          "path": "::ebooklet_html: non-empty response",
+          "id": "4f5f07ddc84fa767ce771b027a452daf",
+          "passes": 109
+        },
+        {
+          "path": "::ebooklet_store: status 200",
+          "id": "832063d4949942e1d469241a566b5ada",
+          "passes": 109,
+          "fails": 0,
+          "name": "ebooklet_store: status 200"
+        },
+        {
+          "name": "ebooklet_store: expected content type",
+          "path": "::ebooklet_store: expected content type",
+          "id": "4bc45407897cacfac72cde03cb436cfc",
+          "passes": 109,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "ebooklet_store: non-empty response",
+          "path": "::ebooklet_store: non-empty response",
+          "id": "ba8131c52dc20ff2e672eb2ebdaf2264",
+          "passes": 109
+        },
+        {
+          "name": "ebooklet_detail: status 200",
+          "path": "::ebooklet_detail: status 200",
+          "id": "6ac2c3d577fd01a668511ac883d2e8d1",
+          "passes": 52,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_detail: expected content type",
+          "path": "::ebooklet_detail: expected content type",
+          "id": "d1bfde1b8fc99c2f24a48267bdc0cc43",
+          "passes": 52,
+          "fails": 0
+        },
+        {
+          "path": "::ebooklet_detail: non-empty response",
+          "id": "e1de9012ed0cadddc1856afba3f02d95",
+          "passes": 52,
+          "fails": 0,
+          "name": "ebooklet_detail: non-empty response"
+        },
+        {
+          "name": "sample_sections: status 200",
+          "path": "::sample_sections: status 200",
+          "id": "f37d3e1fbdc463d3901b957fa5d16256",
+          "passes": 37,
+          "fails": 0
+        },
+        {
+          "path": "::sample_sections: expected content type",
+          "id": "e8bfd786c87b069aba1d85a9a002f882",
+          "passes": 37,
+          "fails": 0,
+          "name": "sample_sections: expected content type"
+        },
+        {
+          "id": "e4c725b88c6752a4fa97e8e7d9694c08",
+          "passes": 37,
+          "fails": 0,
+          "name": "sample_sections: non-empty response",
+          "path": "::sample_sections: non-empty response"
+        },
+        {
+          "name": "contact_settings: status 200",
+          "path": "::contact_settings: status 200",
+          "id": "ab8469c418cc77ecf7dae6d31b4ebd49",
+          "passes": 37,
+          "fails": 0
+        },
+        {
+          "id": "5fc3e4747d868ed95ab339edc01d1d6c",
+          "passes": 37,
+          "fails": 0,
+          "name": "contact_settings: expected content type",
+          "path": "::contact_settings: expected content type"
+        },
+        {
+          "id": "2502a0d78d6164ea3bcd86df3b15c0ec",
+          "passes": 37,
+          "fails": 0,
+          "name": "contact_settings: non-empty response",
+          "path": "::contact_settings: non-empty response"
+        },
+        {
+          "passes": 37,
+          "fails": 0,
+          "name": "health: status 200",
+          "path": "::health: status 200",
+          "id": "73274babb93df6aaf60956333620494b"
+        },
+        {
+          "name": "health: expected content type",
+          "path": "::health: expected content type",
+          "id": "ab62d5933af63d9bbc37dd5d2201fa87",
+          "passes": 37,
+          "fails": 0
+        },
+        {
+          "id": "74df10260207d786119a58cee19a90a2",
+          "passes": 37,
+          "fails": 0,
+          "name": "health: non-empty response",
+          "path": "::health: non-empty response"
+        }
+      ]
+  },
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": ""
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 121836.977
+  },
+  "metrics": {
+    "timeout_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1770
+      },
+      "thresholds": {
+        "rate<0.005": {
+          "ok": true
+        }
+      }
+    },
+    "journey_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 305.1,
+        "p(95)": 347.09999999999997,
+        "p(99)": 384.2399999999999,
+        "max": 469,
+        "avg": 218.25166666666667,
+        "min": 110,
+        "med": 205.5
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1771,
+        "rate": 14.535816987645712
+      }
+    },
+    "http_req_waiting": {
+      "values": {
+        "med": 65.548,
+        "p(90)": 138.894,
+        "p(95)": 150.08099999999996,
+        "p(99)": 181.5389,
+        "max": 291.677,
+        "avg": 85.34082100508165,
+        "min": 51.628
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 294.173,
+        "avg": 87.90805420666283,
+        "min": 51.672,
+        "med": 65.67,
+        "p(90)": 147.669,
+        "p(95)": 168.86149999999995,
+        "p(99)": 208.49889999999996
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.01950762281197067,
+        "min": 0.002,
+        "med": 0.016,
+        "p(90)": 0.035,
+        "p(95)": 0.04249999999999992,
+        "p(99)": 0.06659999999999998,
+        "max": 0.17
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 168.86149999999995,
+        "p(99)": 208.49889999999996,
+        "max": 294.173,
+        "avg": 87.90805420666283,
+        "min": 51.672,
+        "med": 65.67,
+        "p(90)": 147.669
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 2249.33656367,
+        "max": 2391.690542,
+        "avg": 1455.722285343332,
+        "min": 668.635375,
+        "med": 1468.9319580000001,
+        "p(90)": 2057.3487083,
+        "p(95)": 2151.0863225999997
+      }
+    },
+    "server_error_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1770
+      },
+      "thresholds": {
+        "rate<0.02": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 53.2095,
+        "max": 62.634,
+        "avg": 1.6797600225861096,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      },
+      "type": "trend"
+    },
+    "data_received": {
+      "values": {
+        "count": 19160359,
+        "rate": 157262.26529734072
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 25,
+        "min": 25,
+        "max": 25
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 61.0789,
+        "max": 76.607,
+        "avg": 1.933399209486166,
+        "min": 0,
+        "med": 0
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 535702,
+        "rate": 4396.87534269666
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 5310,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      }
+    },
+    "dropped_iterations": {
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count==0": {
+          "ok": true
+        }
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 114.737,
+        "max": 139.305,
+        "avg": 4.525262563523455,
+        "min": 0,
+        "med": 0.006,
+        "p(90)": 0.021,
+        "p(95)": 0.05
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 600,
+        "rate": 4.924613321619101
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 2,
+        "max": 11
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1771
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.012,
+        "med": 0.093,
+        "p(90)": 3.31,
+        "p(95)": 4.949,
+        "p(99)": 56.2677,
+        "max": 72.806,
+        "avg": 2.547725578769057
+      }
+    }
+  },
+  "setup_data": {
+    "startedAt": "2026-07-27T04:57:28.867Z"
+  }
+}

--- a/reports/load-testing/raw/stage-010.json
+++ b/reports/load-testing/raw/stage-010.json
@@ -1,0 +1,539 @@
+{
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 122146.219
+  },
+  "metrics": {
+    "http_req_failed": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 3548
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.062,
+        "max": 0.436,
+        "avg": 0.021230552423901105,
+        "min": 0.003,
+        "med": 0.018,
+        "p(90)": 0.037,
+        "p(95)": 0.043
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 37533649,
+        "rate": 307284.57505508215
+      },
+      "type": "counter"
+    },
+    "journey_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 331,
+        "p(99)": 496,
+        "max": 631,
+        "avg": 214.31640299750208,
+        "min": 109,
+        "med": 191,
+        "p(90)": 302
+      }
+    },
+    "dropped_iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count==0": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 87.14923252536659,
+        "min": 51.065,
+        "med": 64.0705,
+        "p(90)": 137.8496,
+        "p(95)": 164.78074999999987,
+        "p(99)": 210.7823899999997,
+        "max": 411.419
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_blocked": {
+      "values": {
+        "p(90)": 0.025,
+        "p(95)": 0.045,
+        "p(99)": 115.88461,
+        "max": 273.975,
+        "avg": 3.8052336527621557,
+        "min": 0,
+        "med": 0.007
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 40,
+        "max": 40,
+        "value": 40
+      }
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "p(99)": 54.7903,
+        "max": 106.424,
+        "avg": 2.3356240135287534,
+        "min": 0.011,
+        "med": 0.101,
+        "p(90)": 2.845,
+        "p(95)": 3.806449999999998
+      },
+      "type": "trend"
+    },
+    "timeout_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 3547
+      },
+      "thresholds": {
+        "rate<0.005": {
+          "ok": true
+        }
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1201,
+        "rate": 9.832477909119724
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 4,
+        "min": 4,
+        "max": 19
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 53.072979999999994,
+        "max": 211.204,
+        "avg": 1.5559701240135289
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 62.30025,
+        "max": 71.069,
+        "avg": 1.7217266065388956,
+        "min": 0
+      }
+    },
+    "server_error_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 3547
+      },
+      "thresholds": {
+        "rate<0.02": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 10641,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 50.994,
+        "med": 63.9845,
+        "p(90)": 132.4616,
+        "p(95)": 142.33085,
+        "p(99)": 192.03656999999998,
+        "max": 409.806,
+        "avg": 84.79237795941366
+      }
+    },
+    "http_reqs": {
+      "contains": "default",
+      "values": {
+        "count": 3548,
+        "rate": 29.047153723194658
+      },
+      "type": "counter"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 411.419,
+        "avg": 87.14923252536659,
+        "min": 51.065,
+        "med": 64.0705,
+        "p(90)": 137.8496,
+        "p(95)": 164.78074999999987,
+        "p(99)": 210.7823899999997
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1024437,
+        "rate": 8386.972665932459
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 2244.769,
+        "max": 2433.048375,
+        "avg": 1454.0890930141545,
+        "min": 632.554042,
+        "med": 1437.763167,
+        "p(90)": 2076.302709,
+        "p(95)": 2143.69425
+      }
+    }
+  },
+  "setup_data": {
+    "startedAt": "2026-07-27T05:01:21.041Z"
+  },
+  "root_group": {
+    "groups": [],
+    "checks": [
+        {
+          "name": "landing_html: status 200",
+          "path": "::landing_html: status 200",
+          "id": "76fcc46a1860be2ea12ab580b890a5c3",
+          "passes": 546,
+          "fails": 0
+        },
+        {
+          "name": "landing_html: expected content type",
+          "path": "::landing_html: expected content type",
+          "id": "5f0b000b109a559aa9f7be1752443e40",
+          "passes": 546,
+          "fails": 0
+        },
+        {
+          "name": "landing_html: non-empty response",
+          "path": "::landing_html: non-empty response",
+          "id": "53e0fd96940b1d3f0b8101fd2c66d3f9",
+          "passes": 546,
+          "fails": 0
+        },
+        {
+          "passes": 202,
+          "fails": 0,
+          "name": "ebooklet_html: status 200",
+          "path": "::ebooklet_html: status 200",
+          "id": "cbba479753b795ead0c7ee83a2d62296"
+        },
+        {
+          "name": "ebooklet_html: expected content type",
+          "path": "::ebooklet_html: expected content type",
+          "id": "b0ca7ce72227f85363b644263dd32d2e",
+          "passes": 202,
+          "fails": 0
+        },
+        {
+          "path": "::ebooklet_html: non-empty response",
+          "id": "4f5f07ddc84fa767ce771b027a452daf",
+          "passes": 202,
+          "fails": 0,
+          "name": "ebooklet_html: non-empty response"
+        },
+        {
+          "path": "::products_list: status 200",
+          "id": "36ba3e2129d77e15d1ca1f7ec889f3f0",
+          "passes": 887,
+          "fails": 0,
+          "name": "products_list: status 200"
+        },
+        {
+          "passes": 887,
+          "fails": 0,
+          "name": "products_list: expected content type",
+          "path": "::products_list: expected content type",
+          "id": "dfb8c2dc0b626ed47282eb649a92fe12"
+        },
+        {
+          "name": "products_list: non-empty response",
+          "path": "::products_list: non-empty response",
+          "id": "294c5cc6542b98db51b619f63a5a401a",
+          "passes": 887,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_store: status 200",
+          "path": "::ebooklet_store: status 200",
+          "id": "832063d4949942e1d469241a566b5ada",
+          "passes": 202,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_store: expected content type",
+          "path": "::ebooklet_store: expected content type",
+          "id": "4bc45407897cacfac72cde03cb436cfc",
+          "passes": 202,
+          "fails": 0
+        },
+        {
+          "passes": 202,
+          "fails": 0,
+          "name": "ebooklet_store: non-empty response",
+          "path": "::ebooklet_store: non-empty response",
+          "id": "ba8131c52dc20ff2e672eb2ebdaf2264"
+        },
+        {
+          "fails": 0,
+          "name": "sample_sections: status 200",
+          "path": "::sample_sections: status 200",
+          "id": "f37d3e1fbdc463d3901b957fa5d16256",
+          "passes": 112
+        },
+        {
+          "name": "sample_sections: expected content type",
+          "path": "::sample_sections: expected content type",
+          "id": "e8bfd786c87b069aba1d85a9a002f882",
+          "passes": 112,
+          "fails": 0
+        },
+        {
+          "path": "::sample_sections: non-empty response",
+          "id": "e4c725b88c6752a4fa97e8e7d9694c08",
+          "passes": 112,
+          "fails": 0,
+          "name": "sample_sections: non-empty response"
+        },
+        {
+          "name": "contact_settings: status 200",
+          "path": "::contact_settings: status 200",
+          "id": "ab8469c418cc77ecf7dae6d31b4ebd49",
+          "passes": 112,
+          "fails": 0
+        },
+        {
+          "id": "5fc3e4747d868ed95ab339edc01d1d6c",
+          "passes": 112,
+          "fails": 0,
+          "name": "contact_settings: expected content type",
+          "path": "::contact_settings: expected content type"
+        },
+        {
+          "path": "::contact_settings: non-empty response",
+          "id": "2502a0d78d6164ea3bcd86df3b15c0ec",
+          "passes": 112,
+          "fails": 0,
+          "name": "contact_settings: non-empty response"
+        },
+        {
+          "name": "health: status 200",
+          "path": "::health: status 200",
+          "id": "73274babb93df6aaf60956333620494b",
+          "passes": 112,
+          "fails": 0
+        },
+        {
+          "path": "::health: expected content type",
+          "id": "ab62d5933af63d9bbc37dd5d2201fa87",
+          "passes": 112,
+          "fails": 0,
+          "name": "health: expected content type"
+        },
+        {
+          "fails": 0,
+          "name": "health: non-empty response",
+          "path": "::health: non-empty response",
+          "id": "74df10260207d786119a58cee19a90a2",
+          "passes": 112
+        },
+        {
+          "name": "market_html: status 200",
+          "path": "::market_html: status 200",
+          "id": "47ce57d3148632e68074326856b023a1",
+          "passes": 341,
+          "fails": 0
+        },
+        {
+          "passes": 341,
+          "fails": 0,
+          "name": "market_html: expected content type",
+          "path": "::market_html: expected content type",
+          "id": "936bf9e276efc5c9c1e46e08c3955ae1"
+        },
+        {
+          "name": "market_html: non-empty response",
+          "path": "::market_html: non-empty response",
+          "id": "dc009ed78805d5aa7e2eb4459e76aa1a",
+          "passes": 341,
+          "fails": 0
+        },
+        {
+          "id": "5261ab7983594e05def270714e50c43c",
+          "passes": 255,
+          "fails": 0,
+          "name": "product_detail: status 200",
+          "path": "::product_detail: status 200"
+        },
+        {
+          "passes": 255,
+          "fails": 0,
+          "name": "product_detail: expected content type",
+          "path": "::product_detail: expected content type",
+          "id": "3218a9dd21e9dc36f2bd3cd25317d498"
+        },
+        {
+          "passes": 255,
+          "fails": 0,
+          "name": "product_detail: non-empty response",
+          "path": "::product_detail: non-empty response",
+          "id": "3d67d717356cbb8369f4dd3ab14337e8"
+        },
+        {
+          "name": "levels_list: status 200",
+          "path": "::levels_list: status 200",
+          "id": "fa401ddfc5f36f99af49757a3ae7a41f",
+          "passes": 341,
+          "fails": 0
+        },
+        {
+          "path": "::levels_list: expected content type",
+          "id": "d52d104072ffefa55b2ca4dba4701991",
+          "passes": 341,
+          "fails": 0,
+          "name": "levels_list: expected content type"
+        },
+        {
+          "passes": 341,
+          "fails": 0,
+          "name": "levels_list: non-empty response",
+          "path": "::levels_list: non-empty response",
+          "id": "a1b6545baaa93d1d2ef25e782b434d37"
+        },
+        {
+          "path": "::subjects_list: status 200",
+          "id": "ebf2a5e67dff3340f094029a97f82d70",
+          "passes": 341,
+          "fails": 0,
+          "name": "subjects_list: status 200"
+        },
+        {
+          "name": "subjects_list: expected content type",
+          "path": "::subjects_list: expected content type",
+          "id": "1f9264b29ca332aaad8777fb362512d8",
+          "passes": 341,
+          "fails": 0
+        },
+        {
+          "name": "subjects_list: non-empty response",
+          "path": "::subjects_list: non-empty response",
+          "id": "0acc2a36202f32bcbbe3f305657cad1c",
+          "passes": 341,
+          "fails": 0
+        },
+        {
+          "id": "6ac2c3d577fd01a668511ac883d2e8d1",
+          "passes": 96,
+          "fails": 0,
+          "name": "ebooklet_detail: status 200",
+          "path": "::ebooklet_detail: status 200"
+        },
+        {
+          "name": "ebooklet_detail: expected content type",
+          "path": "::ebooklet_detail: expected content type",
+          "id": "d1bfde1b8fc99c2f24a48267bdc0cc43",
+          "passes": 96,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_detail: non-empty response",
+          "path": "::ebooklet_detail: non-empty response",
+          "id": "e1de9012ed0cadddc1856afba3f02d95",
+          "passes": 96,
+          "fails": 0
+        }
+      ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e"
+  }
+}

--- a/reports/load-testing/raw/stage-020.json
+++ b/reports/load-testing/raw/stage-020.json
@@ -1,0 +1,539 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "path": "::landing_html: status 200",
+          "id": "76fcc46a1860be2ea12ab580b890a5c3",
+          "passes": 1082,
+          "fails": 0,
+          "name": "landing_html: status 200"
+        },
+        {
+          "name": "landing_html: expected content type",
+          "path": "::landing_html: expected content type",
+          "id": "5f0b000b109a559aa9f7be1752443e40",
+          "passes": 1082,
+          "fails": 0
+        },
+        {
+          "name": "landing_html: non-empty response",
+          "path": "::landing_html: non-empty response",
+          "id": "53e0fd96940b1d3f0b8101fd2c66d3f9",
+          "passes": 1082,
+          "fails": 0
+        },
+        {
+          "id": "36ba3e2129d77e15d1ca1f7ec889f3f0",
+          "passes": 1787,
+          "fails": 0,
+          "name": "products_list: status 200",
+          "path": "::products_list: status 200"
+        },
+        {
+          "name": "products_list: expected content type",
+          "path": "::products_list: expected content type",
+          "id": "dfb8c2dc0b626ed47282eb649a92fe12",
+          "passes": 1787,
+          "fails": 0
+        },
+        {
+          "name": "products_list: non-empty response",
+          "path": "::products_list: non-empty response",
+          "id": "294c5cc6542b98db51b619f63a5a401a",
+          "passes": 1787,
+          "fails": 0
+        },
+        {
+          "name": "market_html: status 200",
+          "path": "::market_html: status 200",
+          "id": "47ce57d3148632e68074326856b023a1",
+          "passes": 705,
+          "fails": 0
+        },
+        {
+          "name": "market_html: expected content type",
+          "path": "::market_html: expected content type",
+          "id": "936bf9e276efc5c9c1e46e08c3955ae1",
+          "passes": 705,
+          "fails": 0
+        },
+        {
+          "name": "market_html: non-empty response",
+          "path": "::market_html: non-empty response",
+          "id": "dc009ed78805d5aa7e2eb4459e76aa1a",
+          "passes": 705,
+          "fails": 0
+        },
+        {
+          "path": "::product_detail: status 200",
+          "id": "5261ab7983594e05def270714e50c43c",
+          "passes": 490,
+          "fails": 0,
+          "name": "product_detail: status 200"
+        },
+        {
+          "fails": 0,
+          "name": "product_detail: expected content type",
+          "path": "::product_detail: expected content type",
+          "id": "3218a9dd21e9dc36f2bd3cd25317d498",
+          "passes": 490
+        },
+        {
+          "id": "3d67d717356cbb8369f4dd3ab14337e8",
+          "passes": 490,
+          "fails": 0,
+          "name": "product_detail: non-empty response",
+          "path": "::product_detail: non-empty response"
+        },
+        {
+          "path": "::levels_list: status 200",
+          "id": "fa401ddfc5f36f99af49757a3ae7a41f",
+          "passes": 705,
+          "fails": 0,
+          "name": "levels_list: status 200"
+        },
+        {
+          "name": "levels_list: expected content type",
+          "path": "::levels_list: expected content type",
+          "id": "d52d104072ffefa55b2ca4dba4701991",
+          "passes": 705,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "levels_list: non-empty response",
+          "path": "::levels_list: non-empty response",
+          "id": "a1b6545baaa93d1d2ef25e782b434d37",
+          "passes": 705
+        },
+        {
+          "name": "subjects_list: status 200",
+          "path": "::subjects_list: status 200",
+          "id": "ebf2a5e67dff3340f094029a97f82d70",
+          "passes": 705,
+          "fails": 0
+        },
+        {
+          "name": "subjects_list: expected content type",
+          "path": "::subjects_list: expected content type",
+          "id": "1f9264b29ca332aaad8777fb362512d8",
+          "passes": 705,
+          "fails": 0
+        },
+        {
+          "id": "0acc2a36202f32bcbbe3f305657cad1c",
+          "passes": 705,
+          "fails": 0,
+          "name": "subjects_list: non-empty response",
+          "path": "::subjects_list: non-empty response"
+        },
+        {
+          "path": "::ebooklet_html: status 200",
+          "id": "cbba479753b795ead0c7ee83a2d62296",
+          "passes": 424,
+          "fails": 0,
+          "name": "ebooklet_html: status 200"
+        },
+        {
+          "passes": 424,
+          "fails": 0,
+          "name": "ebooklet_html: expected content type",
+          "path": "::ebooklet_html: expected content type",
+          "id": "b0ca7ce72227f85363b644263dd32d2e"
+        },
+        {
+          "name": "ebooklet_html: non-empty response",
+          "path": "::ebooklet_html: non-empty response",
+          "id": "4f5f07ddc84fa767ce771b027a452daf",
+          "passes": 424,
+          "fails": 0
+        },
+        {
+          "id": "832063d4949942e1d469241a566b5ada",
+          "passes": 424,
+          "fails": 0,
+          "name": "ebooklet_store: status 200",
+          "path": "::ebooklet_store: status 200"
+        },
+        {
+          "id": "4bc45407897cacfac72cde03cb436cfc",
+          "passes": 424,
+          "fails": 0,
+          "name": "ebooklet_store: expected content type",
+          "path": "::ebooklet_store: expected content type"
+        },
+        {
+          "name": "ebooklet_store: non-empty response",
+          "path": "::ebooklet_store: non-empty response",
+          "id": "ba8131c52dc20ff2e672eb2ebdaf2264",
+          "passes": 424,
+          "fails": 0
+        },
+        {
+          "id": "6ac2c3d577fd01a668511ac883d2e8d1",
+          "passes": 211,
+          "fails": 0,
+          "name": "ebooklet_detail: status 200",
+          "path": "::ebooklet_detail: status 200"
+        },
+        {
+          "name": "ebooklet_detail: expected content type",
+          "path": "::ebooklet_detail: expected content type",
+          "id": "d1bfde1b8fc99c2f24a48267bdc0cc43",
+          "passes": 211,
+          "fails": 0
+        },
+        {
+          "name": "ebooklet_detail: non-empty response",
+          "path": "::ebooklet_detail: non-empty response",
+          "id": "e1de9012ed0cadddc1856afba3f02d95",
+          "passes": 211,
+          "fails": 0
+        },
+        {
+          "name": "sample_sections: status 200",
+          "path": "::sample_sections: status 200",
+          "id": "f37d3e1fbdc463d3901b957fa5d16256",
+          "passes": 190,
+          "fails": 0
+        },
+        {
+          "passes": 190,
+          "fails": 0,
+          "name": "sample_sections: expected content type",
+          "path": "::sample_sections: expected content type",
+          "id": "e8bfd786c87b069aba1d85a9a002f882"
+        },
+        {
+          "path": "::sample_sections: non-empty response",
+          "id": "e4c725b88c6752a4fa97e8e7d9694c08",
+          "passes": 190,
+          "fails": 0,
+          "name": "sample_sections: non-empty response"
+        },
+        {
+          "id": "ab8469c418cc77ecf7dae6d31b4ebd49",
+          "passes": 190,
+          "fails": 0,
+          "name": "contact_settings: status 200",
+          "path": "::contact_settings: status 200"
+        },
+        {
+          "passes": 190,
+          "fails": 0,
+          "name": "contact_settings: expected content type",
+          "path": "::contact_settings: expected content type",
+          "id": "5fc3e4747d868ed95ab339edc01d1d6c"
+        },
+        {
+          "path": "::contact_settings: non-empty response",
+          "id": "2502a0d78d6164ea3bcd86df3b15c0ec",
+          "passes": 190,
+          "fails": 0,
+          "name": "contact_settings: non-empty response"
+        },
+        {
+          "name": "health: status 200",
+          "path": "::health: status 200",
+          "id": "73274babb93df6aaf60956333620494b",
+          "passes": 190,
+          "fails": 0
+        },
+        {
+          "name": "health: expected content type",
+          "path": "::health: expected content type",
+          "id": "ab62d5933af63d9bbc37dd5d2201fa87",
+          "passes": 190,
+          "fails": 0
+        },
+        {
+          "passes": 190,
+          "fails": 0,
+          "name": "health: non-empty response",
+          "path": "::health: non-empty response",
+          "id": "74df10260207d786119a58cee19a90a2"
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 122362.969
+  },
+  "metrics": {
+    "server_error_rate": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 7103
+      },
+      "thresholds": {
+        "rate<0.02": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 84.17075605292816,
+        "min": 50.732,
+        "med": 62.278999999999996,
+        "p(90)": 134.49689999999998,
+        "p(95)": 149.65534999999988,
+        "p(99)": 192.20653,
+        "max": 364.675
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1.1930349099099096,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 53.59797,
+        "max": 84.974
+      }
+    },
+    "http_req_sending": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0.041,
+        "p(99)": 0.065,
+        "max": 0.315,
+        "avg": 0.022015343468468545,
+        "min": 0.002,
+        "med": 0.02,
+        "p(90)": 0.037
+      },
+      "type": "trend"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2401,
+        "rate": 19.621949513173384
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 7104,
+        "rate": 0
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 21309,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      }
+    },
+    "dropped_iterations": {
+      "thresholds": {
+        "count==0": {
+          "ok": true
+        }
+      },
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 0,
+        "rate": 0
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 70,
+        "value": 70,
+        "min": 70
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 62.75888,
+        "max": 97.068,
+        "avg": 1.3900686936936941,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 55.47626999999999,
+        "max": 62.575,
+        "avg": 2.408257882882884,
+        "min": 0.008,
+        "med": 0.102,
+        "p(90)": 2.8154000000000003,
+        "p(95)": 4.125999999999993
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 7104,
+        "rate": 58.05678023389576
+      }
+    },
+    "data_sent": {
+      "values": {
+        "count": 2001273,
+        "rate": 16355.217729311553
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1459.443505211576,
+        "min": 615.94875,
+        "med": 1455.945875,
+        "p(90)": 2066.820292,
+        "p(95)": 2138.574459,
+        "p(99)": 2234.709834,
+        "max": 2476.808
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0.007,
+        "p(90)": 0.024,
+        "p(95)": 0.039,
+        "p(99)": 117.38020999999998,
+        "max": 179.591,
+        "avg": 3.330268581081362
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 2,
+        "max": 35
+      },
+      "type": "gauge"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 76034030,
+        "rate": 621381.0487060018
+      }
+    },
+    "journey_duration": {
+      "values": {
+        "p(90)": 300,
+        "p(95)": 315,
+        "p(99)": 417,
+        "max": 615,
+        "avg": 208.56601416076634,
+        "min": 107,
+        "med": 189
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "values": {
+        "med": 62.278999999999996,
+        "p(90)": 134.49689999999998,
+        "p(95)": 149.65534999999988,
+        "p(99)": 192.20653,
+        "max": 364.675,
+        "avg": 84.17075605292816,
+        "min": 50.732
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "timeout_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 7103
+      },
+      "thresholds": {
+        "rate<0.005": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_waiting": {
+      "contains": "time",
+      "values": {
+        "avg": 81.7404828265765,
+        "min": 50.691,
+        "med": 62.173500000000004,
+        "p(90)": 129.6549,
+        "p(95)": 136.7894,
+        "p(99)": 164.93658000000002,
+        "max": 353.038
+      },
+      "type": "trend"
+    }
+  },
+  "setup_data": {
+    "startedAt": "2026-07-27T05:03:25.762Z"
+  }
+}

--- a/reports/load-testing/raw/stage-040.json
+++ b/reports/load-testing/raw/stage-040.json
@@ -1,0 +1,547 @@
+{
+  "root_group": {
+    "checks": [
+      {
+        "id": "47ce57d3148632e68074326856b023a1",
+        "passes": 129,
+        "fails": 27,
+        "name": "market_html: status 200",
+        "path": "::market_html: status 200"
+      },
+      {
+        "id": "936bf9e276efc5c9c1e46e08c3955ae1",
+        "passes": 129,
+        "fails": 27,
+        "name": "market_html: expected content type",
+        "path": "::market_html: expected content type"
+      },
+      {
+        "name": "market_html: non-empty response",
+        "path": "::market_html: non-empty response",
+        "id": "dc009ed78805d5aa7e2eb4459e76aa1a",
+        "passes": 129,
+        "fails": 27
+      },
+      {
+        "name": "landing_html: status 200",
+        "path": "::landing_html: status 200",
+        "id": "76fcc46a1860be2ea12ab580b890a5c3",
+        "passes": 223,
+        "fails": 37
+      },
+      {
+        "name": "landing_html: expected content type",
+        "path": "::landing_html: expected content type",
+        "id": "5f0b000b109a559aa9f7be1752443e40",
+        "passes": 223,
+        "fails": 37
+      },
+      {
+        "name": "landing_html: non-empty response",
+        "path": "::landing_html: non-empty response",
+        "id": "53e0fd96940b1d3f0b8101fd2c66d3f9",
+        "passes": 223,
+        "fails": 37
+      },
+      {
+        "name": "products_list: status 200",
+        "path": "::products_list: status 200",
+        "id": "36ba3e2129d77e15d1ca1f7ec889f3f0",
+        "passes": 347,
+        "fails": 0
+      },
+      {
+        "id": "dfb8c2dc0b626ed47282eb649a92fe12",
+        "passes": 347,
+        "fails": 0,
+        "name": "products_list: expected content type",
+        "path": "::products_list: expected content type"
+      },
+      {
+        "path": "::products_list: non-empty response",
+        "id": "294c5cc6542b98db51b619f63a5a401a",
+        "passes": 347,
+        "fails": 0,
+        "name": "products_list: non-empty response"
+      },
+      {
+        "name": "levels_list: status 200",
+        "path": "::levels_list: status 200",
+        "id": "fa401ddfc5f36f99af49757a3ae7a41f",
+        "passes": 128,
+        "fails": 0
+      },
+      {
+        "name": "levels_list: expected content type",
+        "path": "::levels_list: expected content type",
+        "id": "d52d104072ffefa55b2ca4dba4701991",
+        "passes": 128,
+        "fails": 0
+      },
+      {
+        "id": "a1b6545baaa93d1d2ef25e782b434d37",
+        "passes": 128,
+        "fails": 0,
+        "name": "levels_list: non-empty response",
+        "path": "::levels_list: non-empty response"
+      },
+      {
+        "path": "::subjects_list: status 200",
+        "id": "ebf2a5e67dff3340f094029a97f82d70",
+        "passes": 128,
+        "fails": 0,
+        "name": "subjects_list: status 200"
+      },
+      {
+        "name": "subjects_list: expected content type",
+        "path": "::subjects_list: expected content type",
+        "id": "1f9264b29ca332aaad8777fb362512d8",
+        "passes": 128,
+        "fails": 0
+      },
+      {
+        "fails": 0,
+        "name": "subjects_list: non-empty response",
+        "path": "::subjects_list: non-empty response",
+        "id": "0acc2a36202f32bcbbe3f305657cad1c",
+        "passes": 128
+      },
+      {
+        "name": "product_detail: status 200",
+        "path": "::product_detail: status 200",
+        "id": "5261ab7983594e05def270714e50c43c",
+        "passes": 100,
+        "fails": 0
+      },
+      {
+        "name": "product_detail: expected content type",
+        "path": "::product_detail: expected content type",
+        "id": "3218a9dd21e9dc36f2bd3cd25317d498",
+        "passes": 100,
+        "fails": 0
+      },
+      {
+        "name": "product_detail: non-empty response",
+        "path": "::product_detail: non-empty response",
+        "id": "3d67d717356cbb8369f4dd3ab14337e8",
+        "passes": 100,
+        "fails": 0
+      },
+      {
+        "name": "ebooklet_html: status 200",
+        "path": "::ebooklet_html: status 200",
+        "id": "cbba479753b795ead0c7ee83a2d62296",
+        "passes": 94,
+        "fails": 15
+      },
+      {
+        "passes": 94,
+        "fails": 15,
+        "name": "ebooklet_html: expected content type",
+        "path": "::ebooklet_html: expected content type",
+        "id": "b0ca7ce72227f85363b644263dd32d2e"
+      },
+      {
+        "fails": 15,
+        "name": "ebooklet_html: non-empty response",
+        "path": "::ebooklet_html: non-empty response",
+        "id": "4f5f07ddc84fa767ce771b027a452daf",
+        "passes": 94
+      },
+      {
+        "id": "f37d3e1fbdc463d3901b957fa5d16256",
+        "passes": 36,
+        "fails": 7,
+        "name": "sample_sections: status 200",
+        "path": "::sample_sections: status 200"
+      },
+      {
+        "name": "sample_sections: expected content type",
+        "path": "::sample_sections: expected content type",
+        "id": "e8bfd786c87b069aba1d85a9a002f882",
+        "passes": 36,
+        "fails": 7
+      },
+      {
+        "name": "sample_sections: non-empty response",
+        "path": "::sample_sections: non-empty response",
+        "id": "e4c725b88c6752a4fa97e8e7d9694c08",
+        "passes": 36,
+        "fails": 7
+      },
+      {
+        "name": "contact_settings: status 200",
+        "path": "::contact_settings: status 200",
+        "id": "ab8469c418cc77ecf7dae6d31b4ebd49",
+        "passes": 36,
+        "fails": 7
+      },
+      {
+        "name": "contact_settings: expected content type",
+        "path": "::contact_settings: expected content type",
+        "id": "5fc3e4747d868ed95ab339edc01d1d6c",
+        "passes": 36,
+        "fails": 7
+      },
+      {
+        "name": "contact_settings: non-empty response",
+        "path": "::contact_settings: non-empty response",
+        "id": "2502a0d78d6164ea3bcd86df3b15c0ec",
+        "passes": 36,
+        "fails": 7
+      },
+      {
+        "fails": 7,
+        "name": "health: status 200",
+        "path": "::health: status 200",
+        "id": "73274babb93df6aaf60956333620494b",
+        "passes": 36
+      },
+      {
+        "passes": 36,
+        "fails": 7,
+        "name": "health: expected content type",
+        "path": "::health: expected content type",
+        "id": "ab62d5933af63d9bbc37dd5d2201fa87"
+      },
+      {
+        "id": "74df10260207d786119a58cee19a90a2",
+        "passes": 36,
+        "fails": 7,
+        "name": "health: non-empty response",
+        "path": "::health: non-empty response"
+      },
+      {
+        "passes": 94,
+        "fails": 0,
+        "name": "ebooklet_store: status 200",
+        "path": "::ebooklet_store: status 200",
+        "id": "832063d4949942e1d469241a566b5ada"
+      },
+      {
+        "path": "::ebooklet_store: expected content type",
+        "id": "4bc45407897cacfac72cde03cb436cfc",
+        "passes": 94,
+        "fails": 0,
+        "name": "ebooklet_store: expected content type"
+      },
+      {
+        "fails": 0,
+        "name": "ebooklet_store: non-empty response",
+        "path": "::ebooklet_store: non-empty response",
+        "id": "ba8131c52dc20ff2e672eb2ebdaf2264",
+        "passes": 94
+      },
+      {
+        "name": "ebooklet_detail: status 200",
+        "path": "::ebooklet_detail: status 200",
+        "id": "6ac2c3d577fd01a668511ac883d2e8d1",
+        "passes": 37,
+        "fails": 0
+      },
+      {
+        "path": "::ebooklet_detail: expected content type",
+        "id": "d1bfde1b8fc99c2f24a48267bdc0cc43",
+        "passes": 37,
+        "fails": 0,
+        "name": "ebooklet_detail: expected content type"
+      },
+      {
+        "passes": 37,
+        "fails": 0,
+        "name": "ebooklet_detail: non-empty response",
+        "path": "::ebooklet_detail: non-empty response",
+        "id": "e1de9012ed0cadddc1856afba3f02d95"
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": ""
+  },
+  "state": {
+    "testRunDurationMs": 15994.286,
+    "isStdOutTTY": false,
+    "isStdErrTTY": false
+  },
+  "metrics": {
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 1527.605708,
+        "p(90)": 2127.7966748999997,
+        "p(95)": 2206.0545393499997,
+        "p(99)": 10053.145147829995,
+        "max": 11523.445125,
+        "avg": 1651.3092375433769,
+        "min": 644.498583
+      }
+    },
+    "timeout_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.06720430107526881,
+        "passes": 100,
+        "fails": 1388
+      },
+      "thresholds": {
+        "rate<0.005": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 199.91899999999998,
+        "max": 273.542,
+        "avg": 86.65144284687275,
+        "min": 51.188,
+        "med": 64.146,
+        "p(90)": 143.259,
+        "p(95)": 163.26
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 164,
+        "min": 33,
+        "max": 164
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 164,
+        "min": 130,
+        "max": 164
+      }
+    },
+    "server_error_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1488
+      },
+      "thresholds": {
+        "rate<0.02": {
+          "ok": true
+        }
+      }
+    },
+    "journey_failures": {
+      "contains": "default",
+      "values": {
+        "count": 100,
+        "rate": 6.252232828648931
+      },
+      "type": "counter"
+    },
+    "iterations": {
+      "values": {
+        "count": 438,
+        "rate": 27.38477978948232
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "dropped_iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 35,
+        "rate": 2.188281490027126
+      },
+      "thresholds": {
+        "count==0": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_sending": {
+      "contains": "time",
+      "values": {
+        "med": 0.02,
+        "p(90)": 0.036,
+        "p(95)": 0.041,
+        "p(99)": 0.06929999999999996,
+        "max": 1.048,
+        "avg": 0.021967806841046256,
+        "min": 0
+      },
+      "type": "trend"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 56.43649999999998,
+        "p(99)": 63.2686,
+        "max": 70.878,
+        "avg": 3.1586566063044943,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "http_req_waiting": {
+      "values": {
+        "max": 271.373,
+        "avg": 78.69675452716302,
+        "min": 0,
+        "med": 62.082,
+        "p(90)": 136.182,
+        "p(95)": 148.5255,
+        "p(99)": 177.028
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 30173.338153388027,
+        "count": 482601
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 50.79799999999996,
+        "p(99)": 56.987199999999994,
+        "max": 6964.807,
+        "avg": 12.952674044265594
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 2.1210878604963153,
+        "min": 0,
+        "med": 0.085,
+        "p(90)": 2.814,
+        "p(95)": 3.743,
+        "p(99)": 55.086,
+        "max": 60.24
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "count": 1491,
+        "rate": 93.22079147515556
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 300,
+        "rate": 0.9327956989247311,
+        "passes": 4164
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "passes": 100,
+        "fails": 1391,
+        "rate": 0.0670690811535882
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": false
+        }
+      },
+      "type": "rate"
+    },
+    "http_req_duration": {
+      "contains": "time",
+      "values": {
+        "avg": 80.83981019450034,
+        "min": 0,
+        "med": 62.148,
+        "p(90)": 142.378,
+        "p(95)": 160.56199999999998,
+        "p(99)": 199.3108,
+        "max": 273.542
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      },
+      "type": "trend"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 34.67164319248824,
+        "min": 0,
+        "med": 0.007,
+        "p(90)": 117.33,
+        "p(95)": 176.27499999999992,
+        "p(99)": 219.77059999999997,
+        "max": 7028.657
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 14965427,
+        "rate": 935673.3398414908
+      },
+      "type": "counter"
+    },
+    "journey_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 414,
+        "p(99)": 10001,
+        "max": 10002,
+        "avg": 422.3118503118503,
+        "min": 112,
+        "med": 249,
+        "p(90)": 357
+      }
+    }
+  },
+  "setup_data": {
+    "startedAt": "2026-07-27T05:05:30.386Z"
+  }
+}

--- a/tests/performance/k6/README.md
+++ b/tests/performance/k6/README.md
@@ -1,0 +1,17 @@
+# Kalima production capacity test
+
+This K6 suite models anonymous, read-only campaign traffic against the landing page, store, product catalog, e-booklet store, samples, and health endpoint.
+
+It never signs in, creates accounts, modifies carts, checks out, sends messages, or writes application data.
+
+Run one controlled stage:
+
+```sh
+mkdir -p reports/load-testing/raw
+RATE=5 DURATION=2m SUMMARY_PATH=reports/load-testing/raw/stage-005.json \
+  k6 run tests/performance/k6/production-capacity.js
+```
+
+Every request includes `User-Agent: Kalima-Authorized-Capacity-Test/1.0` and `X-Kalima-Load-Test: authorized-production-capacity-test` so test traffic can be identified in logs.
+
+The test aborts when HTTP failures exceed 1%, server errors exceed 2%, timeouts exceed 0.5%, or p95 latency exceeds 3 seconds.

--- a/tests/performance/k6/README.md
+++ b/tests/performance/k6/README.md
@@ -15,3 +15,34 @@ RATE=5 DURATION=2m SUMMARY_PATH=reports/load-testing/raw/stage-005.json \
 Every request includes `User-Agent: Kalima-Authorized-Capacity-Test/1.0` and `X-Kalima-Load-Test: authorized-production-capacity-test` so test traffic can be identified in logs.
 
 The test aborts when HTTP failures exceed 1%, server errors exceed 2%, timeouts exceed 0.5%, or p95 latency exceeds 3 seconds.
+
+## Repository-only authenticated campaign validation
+
+`campaign-authenticated-validation.js` validates a signed-in campaign journey with dedicated credentials provided through environment variables.
+
+It refuses to start unless `CAMPAIGN_TEST_EMAIL` and `CAMPAIGN_TEST_PASSWORD` are set.
+
+Use a dedicated non-production account.
+
+The script blocks paths containing payment, checkout, purchase, confirmation, Paymob, Stripe, or invoice terms before any request is sent.
+
+It does not add cart items, create purchases, confirm purchases, submit payment forms, or call payment endpoints.
+
+Run locally or against an approved staging host:
+
+```sh
+mkdir -p reports/load-testing/raw
+BASE_URL=http://127.0.0.1:5001 \
+CAMPAIGN_TEST_EMAIL=campaign-validation@example.com \
+CAMPAIGN_TEST_PASSWORD='replace-with-dedicated-test-password' \
+CAMPAIGN_VISIT_PATHS='/,/market,/e-booklets' \
+RATE=1 DURATION=1m \
+SUMMARY_PATH=reports/load-testing/raw/campaign-authenticated-validation.json \
+  k6 run tests/performance/k6/campaign-authenticated-validation.js
+```
+
+Optional variables:
+
+- `CAMPAIGN_AUTH_PATH`, default `/api/v1/auth/login`.
+- `CAMPAIGN_VISIT_PATHS`, comma-separated safe page paths, default `/,/market,/e-booklets`.
+- `RATE`, `DURATION`, `PRE_ALLOCATED_VUS`, and `MAX_VUS`, using the same K6 arrival-rate controls as the capacity test.

--- a/tests/performance/k6/campaign-authenticated-validation.js
+++ b/tests/performance/k6/campaign-authenticated-validation.js
@@ -1,0 +1,149 @@
+import http from "k6/http";
+import { check, fail, sleep } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+
+const BASE_URL = (__ENV.BASE_URL || "http://127.0.0.1:5001").replace(/\/$/, "");
+const AUTH_PATH = __ENV.CAMPAIGN_AUTH_PATH || "/api/v1/auth/login";
+const EMAIL = __ENV.CAMPAIGN_TEST_EMAIL;
+const PASSWORD = __ENV.CAMPAIGN_TEST_PASSWORD;
+const VISIT_PATHS = (__ENV.CAMPAIGN_VISIT_PATHS || "/,/market,/e-booklets")
+  .split(",")
+  .map((path) => path.trim())
+  .filter(Boolean);
+const RATE = Number(__ENV.RATE || 1);
+const DURATION = __ENV.DURATION || "1m";
+const PRE_ALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || Math.max(2, RATE * 2));
+const MAX_VUS = Number(__ENV.MAX_VUS || Math.max(5, RATE * 5));
+
+const blockedUnsafeRequests = new Counter("blocked_unsafe_requests");
+const authenticatedJourneyFailures = new Counter("authenticated_journey_failures");
+const authenticatedJourneyDuration = new Trend("authenticated_journey_duration", true);
+const authenticatedServerErrors = new Rate("authenticated_server_error_rate");
+
+const unsafePathPattern = /(?:checkout|payment|purchase|cart-purchases|confirm|paymob|stripe|invoice)/i;
+
+export const options = {
+  discardResponseBodies: false,
+  scenarios: {
+    authenticated_campaign_visitors: {
+      executor: "constant-arrival-rate",
+      rate: RATE,
+      timeUnit: "1s",
+      duration: DURATION,
+      preAllocatedVUs: PRE_ALLOCATED_VUS,
+      maxVUs: MAX_VUS,
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.02"],
+    authenticated_server_error_rate: ["rate<0.02"],
+    authenticated_journey_failures: ["count==0"],
+    blocked_unsafe_requests: ["count==0"],
+    checks: ["rate>0.98"],
+  },
+  userAgent: "Kalima-Repository-Only-Campaign-Validation/1.0",
+  summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+const defaultHeaders = {
+  Accept: "application/json, text/html;q=0.9, */*;q=0.8",
+  "X-Kalima-Load-Test": "repository-only-campaign-validation",
+};
+
+function requireEnv(name, value) {
+  if (!value) {
+    fail(`${name} is required. Use dedicated non-production campaign validation credentials.`);
+  }
+}
+
+function assertSafePath(path) {
+  if (unsafePathPattern.test(path)) {
+    blockedUnsafeRequests.add(1, { path });
+    fail(`Refusing unsafe campaign validation path: ${path}`);
+  }
+}
+
+function extractAccessToken(response) {
+  try {
+    const payload = response.json();
+    return payload?.data?.tokens?.accessToken || payload?.accessToken || payload?.token || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function recordResponse(response, name, expectedStatuses = [200]) {
+  const ok = check(response, {
+    [`${name}: expected status`]: (r) => expectedStatuses.includes(r.status),
+    [`${name}: no server error`]: (r) => r.status < 500,
+  });
+
+  authenticatedServerErrors.add(response.status >= 500, { name });
+  if (!ok) authenticatedJourneyFailures.add(1, { name });
+  return ok;
+}
+
+export function setup() {
+  requireEnv("CAMPAIGN_TEST_EMAIL", EMAIL);
+  requireEnv("CAMPAIGN_TEST_PASSWORD", PASSWORD);
+  assertSafePath(AUTH_PATH);
+  VISIT_PATHS.forEach(assertSafePath);
+
+  const loginResponse = http.post(
+    `${BASE_URL}${AUTH_PATH}`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    {
+      timeout: "10s",
+      headers: {
+        ...defaultHeaders,
+        "Content-Type": "application/json",
+      },
+      tags: { name: "campaign_auth_login", test_type: "repository_only_campaign_validation" },
+    },
+  );
+
+  const loginOk = check(loginResponse, {
+    "login: status 200": (r) => r.status === 200,
+    "login: access token returned": (r) => Boolean(extractAccessToken(r)),
+  });
+
+  if (!loginOk) {
+    fail(`Campaign validation login failed with status ${loginResponse.status}. Use dedicated test credentials only.`);
+  }
+
+  return {
+    accessToken: extractAccessToken(loginResponse),
+    visitPaths: VISIT_PATHS,
+  };
+}
+
+export default function (state) {
+  const started = Date.now();
+  const path = state.visitPaths[(__ITER + __VU) % state.visitPaths.length];
+  assertSafePath(path);
+
+  const response = http.get(`${BASE_URL}${path}`, {
+    timeout: "10s",
+    headers: {
+      ...defaultHeaders,
+      Authorization: `Bearer ${state.accessToken}`,
+    },
+    tags: {
+      name: `campaign_authenticated_visit:${path}`,
+      test_type: "repository_only_campaign_validation",
+    },
+  });
+
+  recordResponse(response, `authenticated visit ${path}`, [200, 204, 301, 302, 304]);
+  authenticatedJourneyDuration.add(Date.now() - started);
+  sleep(Math.random() * 0.75 + 0.25);
+}
+
+export function handleSummary(data) {
+  const output = __ENV.SUMMARY_PATH || "reports/load-testing/raw/campaign-authenticated-validation.json";
+  return {
+    [output]: JSON.stringify(data, null, 2),
+    stdout: `\nKalima repository-only authenticated campaign validation complete. Payment and checkout paths are blocked by the script.\n`,
+  };
+}

--- a/tests/performance/k6/production-capacity.js
+++ b/tests/performance/k6/production-capacity.js
@@ -1,0 +1,146 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+
+const BASE_URL = (__ENV.BASE_URL || "https://kalima-edu.com").replace(/\/$/, "");
+const RATE = Number(__ENV.RATE || 5);
+const DURATION = __ENV.DURATION || "2m";
+const PRE_ALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || Math.max(20, RATE * 2));
+const MAX_VUS = Number(__ENV.MAX_VUS || Math.max(100, RATE * 5));
+
+const serverErrors = new Rate("server_error_rate");
+const timeouts = new Rate("timeout_rate");
+const journeyFailures = new Counter("journey_failures");
+const journeyDuration = new Trend("journey_duration", true);
+
+export const options = {
+  discardResponseBodies: false,
+  scenarios: {
+    campaign_visitors: {
+      executor: "constant-arrival-rate",
+      rate: RATE,
+      timeUnit: "1s",
+      duration: DURATION,
+      preAllocatedVUs: PRE_ALLOCATED_VUS,
+      maxVUs: MAX_VUS,
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    http_req_failed: [
+      { threshold: "rate<0.01", abortOnFail: true, delayAbortEval: "20s" },
+    ],
+    server_error_rate: [
+      { threshold: "rate<0.02", abortOnFail: true, delayAbortEval: "10s" },
+    ],
+    timeout_rate: [
+      { threshold: "rate<0.005", abortOnFail: true, delayAbortEval: "15s" },
+    ],
+    http_req_duration: [
+      { threshold: "p(95)<3000", abortOnFail: true, delayAbortEval: "30s" },
+    ],
+    checks: ["rate>0.99"],
+    dropped_iterations: ["count==0"],
+  },
+  userAgent: "Kalima-Authorized-Capacity-Test/1.0",
+  summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+const defaultParams = {
+  timeout: "10s",
+  headers: {
+    Accept: "application/json, text/html;q=0.9, */*;q=0.8",
+    "X-Kalima-Load-Test": "authorized-production-capacity-test",
+  },
+  tags: { test_type: "authorized_capacity" },
+};
+
+function recordResponse(response, name, expectedContentType) {
+  const successful = check(response, {
+    [`${name}: status 200`]: (r) => r.status === 200,
+    [`${name}: expected content type`]: (r) =>
+      String(r.headers["Content-Type"] || "").includes(expectedContentType),
+    [`${name}: non-empty response`]: (r) => Boolean(r.body && r.body.length > 0),
+  });
+
+  serverErrors.add(response.status >= 500, { name });
+  timeouts.add(response.error_code === 1050, { name });
+  if (!successful) journeyFailures.add(1, { name });
+  return successful;
+}
+
+function get(path, name, expectedContentType = "application/json") {
+  const response = http.get(`${BASE_URL}${path}`, {
+    ...defaultParams,
+    tags: { ...defaultParams.tags, name },
+  });
+  recordResponse(response, name, expectedContentType);
+  return response;
+}
+
+function firstId(response) {
+  try {
+    const payload = response.json();
+    const data = Array.isArray(payload) ? payload : payload.data;
+    return Array.isArray(data) && data.length ? data[0].id : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function setup() {
+  const health = http.get(`${BASE_URL}/api/v2/health`, defaultParams);
+  if (health.status !== 200) {
+    throw new Error(`Preflight failed: health returned ${health.status}`);
+  }
+  return { startedAt: new Date().toISOString() };
+}
+
+export default function () {
+  const started = Date.now();
+  const journey = Math.random();
+
+  if (journey < 0.45) {
+    get("/", "landing_html", "text/html");
+    const products = get("/api/v2/products", "products_list");
+    const productId = firstId(products);
+    if (productId && Math.random() < 0.45) {
+      get(`/api/v2/products/${productId}`, "product_detail");
+    }
+  } else if (journey < 0.75) {
+    get("/market", "market_html", "text/html");
+    http.batch([
+      ["GET", `${BASE_URL}/api/v2/products`, null, { ...defaultParams, tags: { name: "products_list" } }],
+      ["GET", `${BASE_URL}/api/v2/levels`, null, { ...defaultParams, tags: { name: "levels_list" } }],
+      ["GET", `${BASE_URL}/api/v2/subjects`, null, { ...defaultParams, tags: { name: "subjects_list" } }],
+    ]).forEach((response, index) =>
+      recordResponse(response, ["products_list", "levels_list", "subjects_list"][index], "application/json"),
+    );
+  } else if (journey < 0.92) {
+    get("/e-booklets", "ebooklet_html", "text/html");
+    const templates = get("/api/v2/e-booklet-store", "ebooklet_store");
+    const templateId = firstId(templates);
+    if (templateId && Math.random() < 0.5) {
+      get(`/api/v2/e-booklet-store/${templateId}`, "ebooklet_detail");
+    }
+  } else {
+    http.batch([
+      ["GET", `${BASE_URL}/api/v2/sample-sections`, null, { ...defaultParams, tags: { name: "sample_sections" } }],
+      ["GET", `${BASE_URL}/api/v2/settings/contact`, null, { ...defaultParams, tags: { name: "contact_settings" } }],
+      ["GET", `${BASE_URL}/api/v2/health`, null, { ...defaultParams, tags: { name: "health" } }],
+    ]).forEach((response, index) =>
+      recordResponse(response, ["sample_sections", "contact_settings", "health"][index], "application/json"),
+    );
+  }
+
+  journeyDuration.add(Date.now() - started);
+  sleep(Math.random() * 1.5 + 0.5);
+}
+
+export function handleSummary(data) {
+  const output = __ENV.SUMMARY_PATH || "summary.json";
+  return {
+    [output]: JSON.stringify(data, null, 2),
+    stdout: `\nKalima production capacity stage complete: ${RATE} journeys/s for ${DURATION}\n`,
+  };
+}


### PR DESCRIPTION
Adds production capacity benchmarks, Compose resource and health protections, protected Prometheus metrics, authenticated K6 validation, browser performance coverage, and switches the application to independently managed PostgreSQL and Redis services. Production backups and standalone data services are prepared before merge.